### PR TITLE
Phase 2 — EZ1 HTTP adapter and probe CLI

### DIFF
--- a/src/ez1_bridge/__main__.py
+++ b/src/ez1_bridge/__main__.py
@@ -1,14 +1,17 @@
 """Module entrypoint — enables ``python -m ez1_bridge``.
 
-Implementation lands in Phase 6 (CLI subcommands: ``run``, ``probe``, ``--version``).
+Wires :func:`ez1_bridge.main.cli_entrypoint` (which returns an exit code)
+into :func:`sys.exit` so the process status reflects the CLI outcome.
 """
+
+import sys
 
 from ez1_bridge.main import cli_entrypoint
 
 
 def main() -> None:
-    """Forward to :func:`ez1_bridge.main.cli_entrypoint`."""
-    cli_entrypoint()
+    """Forward to :func:`ez1_bridge.main.cli_entrypoint` and propagate exit code."""
+    sys.exit(cli_entrypoint())
 
 
 if __name__ == "__main__":

--- a/src/ez1_bridge/adapters/ez1_http.py
+++ b/src/ez1_bridge/adapters/ez1_http.py
@@ -1,8 +1,212 @@
 """Async HTTP client for the APsystems EZ1 local API on TCP/8050.
 
-Wraps the seven endpoints documented in ``docs/_reference/apsystems-ez1-local-api.md``:
-``getDeviceInfo``, ``getOutputData``, ``getMaxPower``, ``setMaxPower``,
-``getAlarm``, ``getOnOff``, ``setOnOff``.
+Wraps the seven endpoints documented in
+``docs/_reference/apsystems-ez1-local-api.md``: ``getDeviceInfo``,
+``getOutputData``, ``getMaxPower``, ``setMaxPower``, ``getAlarm``,
+``getOnOff``, ``setOnOff``. Returns the raw envelope dict for each call;
+parsing/validation is the normalizer's job in
+:mod:`ez1_bridge.domain.normalizer`.
 
-Implementation lands in Phase 2.
+Designed as an async context manager so the underlying
+:class:`httpx.AsyncClient` is reused across the bridge's lifetime --
+TCP keep-alive on the 45-90 ms WLAN round-trip is the cheapest
+performance win available, and reconnecting per request would dominate
+the poll budget.
+
+Retry behaviour is deliberately *not* a blanket decorator. A single
+classifier (:func:`_is_transient`) decides per exception type:
+
+* :class:`httpx.ConnectError` → fail fast (device offline, hammering
+  does not help; the next poll cycle will try again).
+* :class:`httpx.TimeoutException` → retry with exponential backoff.
+* :class:`httpx.HTTPStatusError` 5xx → retry with exponential backoff.
+* :class:`httpx.HTTPStatusError` 4xx → fail fast (programming error,
+  not transient).
+
+Application-level "envelope says ``message="FAILED"``" handling lives
+in the normalizer / poll service, not here — the adapter only owns
+transport concerns.
 """
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from types import TracebackType
+from typing import Any, Final, Self
+
+import httpx
+
+_DEFAULT_TIMEOUT: Final[float] = 5.0
+_DEFAULT_MAX_ATTEMPTS: Final[int] = 3
+_BACKOFF_BASE_SECONDS: Final[float] = 1.0
+_BACKOFF_CAP_SECONDS: Final[float] = 300.0
+# HTTP 5xx range — Server errors that the EZ1 may emit during transient
+# overloads. Fenced as constants to silence ruff's PLR2004 magic-number lint
+# and to make the intent explicit at the comparison site.
+_HTTP_SERVER_ERROR_LO: Final[int] = 500
+_HTTP_SERVER_ERROR_HI: Final[int] = 600
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """Return ``True`` if the exception represents a transient transport error.
+
+    Drives the retry decision in :meth:`EZ1Client._request`. Defined as a
+    standalone function (not a method) so tests can exercise the policy
+    without instantiating a client.
+    """
+    match exc:
+        case httpx.TimeoutException():
+            return True
+        case httpx.HTTPStatusError() as e if (
+            _HTTP_SERVER_ERROR_LO <= e.response.status_code < _HTTP_SERVER_ERROR_HI
+        ):
+            return True
+        case _:
+            return False
+
+
+def _backoff_seconds(attempt: int) -> float:
+    """Exponential backoff: 1.0 s, 2.0 s, 4.0 s, ... capped at 300 s.
+
+    ``attempt`` is 1-indexed — the wait *after* the first failed attempt
+    is :func:`_backoff_seconds(1)`.
+    """
+    return min(_BACKOFF_BASE_SECONDS * (2.0 ** (attempt - 1)), _BACKOFF_CAP_SECONDS)
+
+
+class EZ1Client:
+    """Async HTTP client for the APsystems EZ1 local API.
+
+    Use as an async context manager so the underlying
+    :class:`httpx.AsyncClient` is created (and torn down) exactly once::
+
+        async with EZ1Client("192.168.3.24") as client:
+            envelope = await client.get_output_data()
+
+    Calling a method outside the context manager raises
+    :class:`RuntimeError`.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 8050,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT,
+        max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    ) -> None:
+        if not host:
+            msg = "host must be a non-empty string"
+            raise ValueError(msg)
+        if max_attempts < 1:
+            msg = "max_attempts must be >= 1"
+            raise ValueError(msg)
+        self._base_url = f"http://{host}:{port}"
+        self._timeout = timeout
+        self._max_attempts = max_attempts
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Resolved base URL (``http://<host>:<port>``)."""
+        return self._base_url
+
+    async def __aenter__(self) -> Self:
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=self._timeout,
+            limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    def _ensure_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            msg = "EZ1Client must be used as an async context manager"
+            raise RuntimeError(msg)
+        return self._client
+
+    async def _request(
+        self,
+        path: str,
+        params: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """GET ``path`` with retry policy and return the parsed JSON envelope."""
+        client = self._ensure_client()
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                response = await client.get(path, params=params)
+                response.raise_for_status()
+            except (httpx.HTTPStatusError, httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_exc = exc
+                if attempt < self._max_attempts and _is_transient(exc):
+                    await asyncio.sleep(_backoff_seconds(attempt))
+                    continue
+                raise
+            else:
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    msg = (
+                        f"unexpected response shape from {path}: "
+                        f"expected JSON object, got {type(payload).__name__}"
+                    )
+                    raise TypeError(msg)
+                return payload
+        # All attempts exhausted with transient failures — re-raise the last one.
+        assert last_exc is not None  # noqa: S101 — invariant from the loop above.
+        raise last_exc
+
+    # --- Read endpoints --------------------------------------------------
+
+    async def get_device_info(self) -> dict[str, Any]:
+        """``GET /getDeviceInfo`` — device static metadata."""
+        return await self._request("/getDeviceInfo")
+
+    async def get_output_data(self) -> dict[str, Any]:
+        """``GET /getOutputData`` — instantaneous power and energy readings."""
+        return await self._request("/getOutputData")
+
+    async def get_max_power(self) -> dict[str, Any]:
+        """``GET /getMaxPower`` — currently configured output limit."""
+        return await self._request("/getMaxPower")
+
+    async def get_alarm(self) -> dict[str, Any]:
+        """``GET /getAlarm`` — diagnostic alarm bits."""
+        return await self._request("/getAlarm")
+
+    async def get_on_off(self) -> dict[str, Any]:
+        """``GET /getOnOff`` — operational status (note inverted semantics)."""
+        return await self._request("/getOnOff")
+
+    # --- Write endpoints -------------------------------------------------
+
+    async def set_max_power(self, watts: int) -> dict[str, Any]:
+        """``GET /setMaxPower?p=<watts>`` — set the inverter's output limit.
+
+        ``watts`` must be within the device's ``minPower``/``maxPower``
+        range; that bound check is a higher-layer concern (see
+        :mod:`ez1_bridge.application.command_handler`) and is not
+        enforced here.
+        """
+        return await self._request("/setMaxPower", params={"p": str(watts)})
+
+    async def set_on_off(self, *, on: bool) -> dict[str, Any]:
+        """``GET /setOnOff?status=<0|1>`` — turn the inverter on or off.
+
+        The on/off bit is inverted on the wire (``0`` is *on*,
+        ``1`` is *off*); this method takes a boolean ``on=True/False``
+        and applies the mapping internally so callers do not have to
+        memorize the inversion.
+        """
+        return await self._request("/setOnOff", params={"status": "0" if on else "1"})

--- a/src/ez1_bridge/main.py
+++ b/src/ez1_bridge/main.py
@@ -1,12 +1,135 @@
-"""Application entrypoint and signal handling.
+"""Application entrypoint, signal handling, and CLI dispatch.
 
-Wires the configuration, logging, MQTT, EZ1 client, metrics server, and the
-poll/command/heartbeat coroutines into a single ``asyncio.TaskGroup``.
-
-Implementation lands in Phase 4 (poll loop) and Phase 6 (CLI subcommands).
+Currently exposes the read-only :func:`_probe` health check and an
+argparse-based :func:`cli_entrypoint`. The full bridge service (poll
+loop, command dispatcher, metrics server, signal handling) lands in
+Phase 6 under the ``run`` subcommand, which currently raises
+:class:`NotImplementedError` to keep the CLI surface visible.
 """
 
+from __future__ import annotations
 
-def cli_entrypoint() -> None:
-    """CLI entrypoint stub — replaced in Phase 6."""
-    raise NotImplementedError("CLI entrypoint is implemented in Phase 6.")
+import argparse
+import asyncio
+import json as json_lib
+import sys
+from typing import Any, Final
+
+from ez1_bridge import __version__
+from ez1_bridge.adapters.ez1_http import EZ1Client
+
+#: Tuple of (wire-name, EZ1Client method name) for the five read endpoints.
+#: ``probe`` is read-only by design — write endpoints are not listed here so
+#: an accidental refactor cannot turn the health check destructive.
+_READ_ENDPOINTS: Final[tuple[tuple[str, str], ...]] = (
+    ("getDeviceInfo", "get_device_info"),
+    ("getOutputData", "get_output_data"),
+    ("getMaxPower", "get_max_power"),
+    ("getAlarm", "get_alarm"),
+    ("getOnOff", "get_on_off"),
+)
+
+
+async def _probe(*, host: str, port: int, json_output: bool) -> int:
+    """Run a read-only health check against the five EZ1 read endpoints.
+
+    Returns ``0`` if every endpoint responds with ``message == "SUCCESS"``,
+    ``1`` otherwise. Designed for use as a CI smoke test against real
+    hardware (Phase 7) and as a quick local diagnostic.
+
+    Never issues a write call. Adding a write endpoint to this routine
+    would require a new fixture name and changes to the CLI surface --
+    keep it that way.
+    """
+    results: list[dict[str, Any]] = []
+
+    async with EZ1Client(host=host, port=port) as client:
+        for endpoint_name, method_name in _READ_ENDPOINTS:
+            method = getattr(client, method_name)
+            try:
+                envelope = await method()
+            except Exception as exc:
+                results.append(
+                    {
+                        "endpoint": endpoint_name,
+                        "ok": False,
+                        "detail": f"{type(exc).__name__}: {exc}",
+                    },
+                )
+                continue
+
+            ok = envelope.get("message") == "SUCCESS"
+            detail = "OK" if ok else f"message={envelope.get('message')!r}"
+            results.append({"endpoint": endpoint_name, "ok": ok, "detail": detail})
+
+    if json_output:
+        sys.stdout.write(
+            json_lib.dumps({"host": host, "port": port, "results": results}) + "\n",
+        )
+    else:
+        sys.stdout.write(f"EZ1 probe -> {host}:{port}\n")
+        for r in results:
+            mark = "OK  " if r["ok"] else "FAIL"
+            sys.stdout.write(f"  [{mark}] {r['endpoint']:<15} {r['detail']}\n")
+
+    return 0 if all(r["ok"] for r in results) else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser. Extracted for testability."""
+    parser = argparse.ArgumentParser(
+        prog="ez1-bridge",
+        description="MQTT bridge for the APsystems EZ1-M micro inverter.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"ez1-bridge {__version__}",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    probe = sub.add_parser(
+        "probe",
+        help="Read-only health check of the EZ1 local API.",
+        description=(
+            "Hit each of the five EZ1 read endpoints and report SUCCESS or "
+            "FAILED. Exit code 0 if all endpoints respond cleanly, 1 "
+            "otherwise. No write calls are issued."
+        ),
+    )
+    probe.add_argument("--host", required=True, help="EZ1 host or IP address")
+    probe.add_argument("--port", type=int, default=8050, help="TCP port (default: 8050)")
+    probe.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit a JSON object instead of human-readable output",
+    )
+
+    sub.add_parser(
+        "run",
+        help="Run the bridge service (implemented in Phase 6).",
+    )
+
+    return parser
+
+
+def cli_entrypoint(argv: list[str] | None = None) -> int:
+    """Top-level CLI dispatch — invoked by ``python -m ez1_bridge``.
+
+    Returns the process exit code. The :mod:`ez1_bridge.__main__` shim
+    wraps this in :func:`sys.exit`.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "probe":
+        return asyncio.run(
+            _probe(host=args.host, port=args.port, json_output=args.json_output),
+        )
+    if args.command == "run":
+        msg = "`run` is implemented in Phase 6."
+        raise NotImplementedError(msg)
+
+    parser.print_help(sys.stderr)
+    return 2

--- a/tests/unit/test_ez1_http.py
+++ b/tests/unit/test_ez1_http.py
@@ -1,0 +1,289 @@
+"""Tests for :mod:`ez1_bridge.adapters.ez1_http`.
+
+Uses ``respx`` to mock the underlying ``httpx`` transport. The five
+verified payload fixtures from ``tests/fixtures/api_responses/`` drive
+the read-endpoint happy paths; retry classification and write-endpoint
+query-string handling get dedicated tests.
+
+Backoff sleeps are monkeypatched to zero in retry tests so the suite
+stays fast — the *order* of attempts and the *number of calls* are
+what we are checking, not the actual wall-clock waits.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from ez1_bridge.adapters.ez1_http import (
+    EZ1Client,
+    _backoff_seconds,
+    _is_transient,
+)
+
+# --- _is_transient classifier ------------------------------------------
+
+
+def test_is_transient_timeout() -> None:
+    assert _is_transient(httpx.TimeoutException("timeout")) is True
+
+
+def test_is_transient_5xx() -> None:
+    response = httpx.Response(503, request=httpx.Request("GET", "http://x"))
+    exc = httpx.HTTPStatusError("503", request=response.request, response=response)
+    assert _is_transient(exc) is True
+
+
+def test_is_transient_4xx_is_not() -> None:
+    response = httpx.Response(404, request=httpx.Request("GET", "http://x"))
+    exc = httpx.HTTPStatusError("404", request=response.request, response=response)
+    assert _is_transient(exc) is False
+
+
+def test_is_transient_connect_error_is_not() -> None:
+    assert _is_transient(httpx.ConnectError("refused")) is False
+
+
+def test_is_transient_unrelated_exception() -> None:
+    assert _is_transient(RuntimeError("boom")) is False
+
+
+# --- _backoff_seconds --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("attempt", "expected"),
+    [(1, 1.0), (2, 2.0), (3, 4.0), (4, 8.0), (5, 16.0)],
+)
+def test_backoff_seconds_doubles_per_attempt(attempt: int, expected: float) -> None:
+    assert _backoff_seconds(attempt) == expected
+
+
+def test_backoff_seconds_caps_at_300() -> None:
+    # 2^9 = 512 > 300 — should cap.
+    assert _backoff_seconds(10) == 300.0
+    assert _backoff_seconds(20) == 300.0
+
+
+# --- helpers -----------------------------------------------------------
+
+
+@pytest.fixture
+def fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace :func:`_backoff_seconds` with a zero-wait stub."""
+    monkeypatch.setattr(
+        "ez1_bridge.adapters.ez1_http._backoff_seconds",
+        lambda _attempt: 0.0,
+    )
+
+
+_HOST = "192.168.3.24"
+_BASE = f"http://{_HOST}:8050"
+
+
+# --- Read endpoints — happy paths --------------------------------------
+
+
+@respx.mock
+async def test_get_device_info_returns_envelope(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    respx.get(f"{_BASE}/getDeviceInfo").respond(json=api_response("get_device_info"))
+    async with EZ1Client(_HOST) as client:
+        envelope = await client.get_device_info()
+    assert envelope["message"] == "SUCCESS"
+    assert envelope["data"]["deviceId"] == "E17010000783"
+    assert envelope["data"]["maxPower"] == "800"
+
+
+@respx.mock
+async def test_get_output_data_returns_envelope(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    respx.get(f"{_BASE}/getOutputData").respond(json=api_response("get_output_data"))
+    async with EZ1Client(_HOST) as client:
+        envelope = await client.get_output_data()
+    assert envelope["data"]["p1"] == 139
+    assert envelope["data"]["te2"] == 111.24305
+
+
+@respx.mock
+async def test_get_max_power_returns_envelope(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    respx.get(f"{_BASE}/getMaxPower").respond(json=api_response("get_max_power"))
+    async with EZ1Client(_HOST) as client:
+        envelope = await client.get_max_power()
+    assert envelope["data"]["maxPower"] == "800"
+
+
+@respx.mock
+async def test_get_alarm_returns_envelope(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    respx.get(f"{_BASE}/getAlarm").respond(json=api_response("get_alarm"))
+    async with EZ1Client(_HOST) as client:
+        envelope = await client.get_alarm()
+    assert envelope["data"]["og"] == "0"
+
+
+@respx.mock
+async def test_get_on_off_returns_envelope(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    respx.get(f"{_BASE}/getOnOff").respond(json=api_response("get_on_off"))
+    async with EZ1Client(_HOST) as client:
+        envelope = await client.get_on_off()
+    assert envelope["data"]["status"] == "0"
+
+
+# --- Write endpoints — query string assertions -------------------------
+
+
+@respx.mock
+async def test_set_max_power_sends_p_param() -> None:
+    route = respx.get(f"{_BASE}/setMaxPower").respond(
+        json={"data": {"maxPower": "600"}, "message": "SUCCESS", "deviceId": "E17010000783"},
+    )
+    async with EZ1Client(_HOST) as client:
+        envelope = await client.set_max_power(600)
+    assert envelope["message"] == "SUCCESS"
+    assert route.call_count == 1
+    request = route.calls.last.request
+    assert request.url.params["p"] == "600"
+
+
+@respx.mock
+async def test_set_on_off_on_sends_status_zero() -> None:
+    route = respx.get(f"{_BASE}/setOnOff").respond(
+        json={"data": {"status": "0"}, "message": "SUCCESS", "deviceId": "E17010000783"},
+    )
+    async with EZ1Client(_HOST) as client:
+        await client.set_on_off(on=True)
+    assert route.calls.last.request.url.params["status"] == "0"
+
+
+@respx.mock
+async def test_set_on_off_off_sends_status_one() -> None:
+    route = respx.get(f"{_BASE}/setOnOff").respond(
+        json={"data": {"status": "1"}, "message": "SUCCESS", "deviceId": "E17010000783"},
+    )
+    async with EZ1Client(_HOST) as client:
+        await client.set_on_off(on=False)
+    assert route.calls.last.request.url.params["status"] == "1"
+
+
+# --- Retry behaviour ---------------------------------------------------
+
+
+@respx.mock
+async def test_timeout_retries_then_succeeds(
+    api_response: Callable[[str], dict[str, Any]],
+    fast_backoff: None,
+) -> None:
+    """Timeout is transient → retried until max_attempts is reached."""
+    route = respx.get(f"{_BASE}/getOutputData").mock(
+        side_effect=[
+            httpx.TimeoutException("first attempt timed out"),
+            httpx.TimeoutException("second attempt timed out"),
+            httpx.Response(200, json=api_response("get_output_data")),
+        ],
+    )
+    async with EZ1Client(_HOST, max_attempts=3) as client:
+        envelope = await client.get_output_data()
+    assert envelope["message"] == "SUCCESS"
+    assert route.call_count == 3
+
+
+@respx.mock
+async def test_timeout_exhausts_attempts(fast_backoff: None) -> None:
+    route = respx.get(f"{_BASE}/getOutputData").mock(
+        side_effect=httpx.TimeoutException("always timeout"),
+    )
+    async with EZ1Client(_HOST, max_attempts=3) as client:
+        with pytest.raises(httpx.TimeoutException):
+            await client.get_output_data()
+    assert route.call_count == 3
+
+
+@respx.mock
+async def test_5xx_retries_then_succeeds(
+    api_response: Callable[[str], dict[str, Any]],
+    fast_backoff: None,
+) -> None:
+    """5xx is transient (broker hiccup) → retried."""
+    route = respx.get(f"{_BASE}/getOutputData").mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(502),
+            httpx.Response(200, json=api_response("get_output_data")),
+        ],
+    )
+    async with EZ1Client(_HOST, max_attempts=3) as client:
+        envelope = await client.get_output_data()
+    assert envelope["message"] == "SUCCESS"
+    assert route.call_count == 3
+
+
+@respx.mock
+async def test_4xx_fails_fast() -> None:
+    """4xx is a programming error — never retried."""
+    route = respx.get(f"{_BASE}/getOutputData").respond(404)
+    async with EZ1Client(_HOST, max_attempts=5) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_output_data()
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_connect_error_fails_fast() -> None:
+    """ConnectError means the device is offline; retrying does not help."""
+    route = respx.get(f"{_BASE}/getOutputData").mock(
+        side_effect=httpx.ConnectError("Connection refused"),
+    )
+    async with EZ1Client(_HOST, max_attempts=5) as client:
+        with pytest.raises(httpx.ConnectError):
+            await client.get_output_data()
+    assert route.call_count == 1
+
+
+# --- Context manager enforcement ---------------------------------------
+
+
+async def test_call_outside_context_manager_raises() -> None:
+    client = EZ1Client(_HOST)
+    with pytest.raises(RuntimeError, match="async context manager"):
+        await client.get_output_data()
+
+
+# --- Construction guards -----------------------------------------------
+
+
+def test_empty_host_rejected() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        EZ1Client("")
+
+
+def test_zero_max_attempts_rejected() -> None:
+    with pytest.raises(ValueError, match="max_attempts"):
+        EZ1Client(_HOST, max_attempts=0)
+
+
+def test_base_url_is_resolvable() -> None:
+    client = EZ1Client("10.0.0.5", port=9999)
+    assert client.base_url == "http://10.0.0.5:9999"
+
+
+# --- Defensive type guards on the response -----------------------------
+
+
+@respx.mock
+async def test_non_object_json_response_rejected() -> None:
+    respx.get(f"{_BASE}/getMaxPower").respond(json=["not", "an", "object"])
+    async with EZ1Client(_HOST) as client:
+        with pytest.raises(TypeError, match="JSON object"):
+            await client.get_max_power()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,194 @@
+"""Tests for :mod:`ez1_bridge.main` — the probe CLI and dispatch shim."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from ez1_bridge.main import _probe, cli_entrypoint
+
+_HOST = "192.168.3.24"
+_PORT = 8050
+_BASE = f"http://{_HOST}:{_PORT}"
+
+
+def _arm_all_success(api_response: Callable[[str], dict[str, Any]]) -> None:
+    """Configure respx to answer every read endpoint with a verified payload."""
+    respx.get(f"{_BASE}/getDeviceInfo").respond(json=api_response("get_device_info"))
+    respx.get(f"{_BASE}/getOutputData").respond(json=api_response("get_output_data"))
+    respx.get(f"{_BASE}/getMaxPower").respond(json=api_response("get_max_power"))
+    respx.get(f"{_BASE}/getAlarm").respond(json=api_response("get_alarm"))
+    respx.get(f"{_BASE}/getOnOff").respond(json=api_response("get_on_off"))
+
+
+# --- _probe ------------------------------------------------------------
+
+
+@respx.mock
+async def test_probe_returns_zero_when_all_endpoints_succeed(
+    api_response: Callable[[str], dict[str, Any]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _arm_all_success(api_response)
+
+    exit_code = await _probe(host=_HOST, port=_PORT, json_output=False)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "EZ1 probe" in captured.out
+    assert "[OK  ]" in captured.out
+    assert "getDeviceInfo" in captured.out
+    assert "getOnOff" in captured.out
+
+
+@respx.mock
+async def test_probe_returns_one_when_an_endpoint_fails_with_message(
+    api_response: Callable[[str], dict[str, Any]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _arm_all_success(api_response)
+    failing = api_response("get_alarm").copy()
+    failing["message"] = "FAILED"
+    respx.get(f"{_BASE}/getAlarm").respond(json=failing)
+
+    exit_code = await _probe(host=_HOST, port=_PORT, json_output=False)
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "message='FAILED'" in out
+
+
+@respx.mock
+async def test_probe_returns_one_when_endpoint_raises(
+    api_response: Callable[[str], dict[str, Any]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _arm_all_success(api_response)
+    respx.get(f"{_BASE}/getOutputData").mock(
+        side_effect=httpx.ConnectError("Connection refused"),
+    )
+
+    exit_code = await _probe(host=_HOST, port=_PORT, json_output=False)
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "ConnectError" in out
+
+
+@respx.mock
+async def test_probe_emits_json_when_requested(
+    api_response: Callable[[str], dict[str, Any]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _arm_all_success(api_response)
+
+    exit_code = await _probe(host=_HOST, port=_PORT, json_output=True)
+
+    assert exit_code == 0
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["host"] == _HOST
+    assert parsed["port"] == _PORT
+    assert len(parsed["results"]) == 5
+    assert all(r["ok"] is True for r in parsed["results"])
+    endpoint_names = [r["endpoint"] for r in parsed["results"]]
+    assert endpoint_names == [
+        "getDeviceInfo",
+        "getOutputData",
+        "getMaxPower",
+        "getAlarm",
+        "getOnOff",
+    ]
+
+
+@respx.mock
+async def test_probe_does_not_call_write_endpoints(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    """`probe` is read-only by design — guard rail against accidental destructive refactors."""
+    _arm_all_success(api_response)
+    write_set_max = respx.get(f"{_BASE}/setMaxPower").respond(json={"unused": True})
+    write_set_on_off = respx.get(f"{_BASE}/setOnOff").respond(json={"unused": True})
+
+    await _probe(host=_HOST, port=_PORT, json_output=False)
+
+    assert write_set_max.call_count == 0
+    assert write_set_on_off.call_count == 0
+
+
+# --- cli_entrypoint dispatch ------------------------------------------
+
+
+@respx.mock
+def test_cli_entrypoint_dispatches_probe(
+    api_response: Callable[[str], dict[str, Any]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _arm_all_success(api_response)
+
+    exit_code = cli_entrypoint(["probe", "--host", _HOST])
+
+    assert exit_code == 0
+    assert "EZ1 probe" in capsys.readouterr().out
+
+
+@respx.mock
+def test_cli_entrypoint_propagates_probe_failure(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    _arm_all_success(api_response)
+    failing = api_response("get_max_power").copy()
+    failing["message"] = "FAILED"
+    respx.get(f"{_BASE}/getMaxPower").respond(json=failing)
+
+    exit_code = cli_entrypoint(["probe", "--host", _HOST])
+
+    assert exit_code == 1
+
+
+@respx.mock
+def test_cli_entrypoint_probe_json_flag(
+    api_response: Callable[[str], dict[str, Any]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _arm_all_success(api_response)
+
+    exit_code = cli_entrypoint(["probe", "--host", _HOST, "--json"])
+
+    assert exit_code == 0
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["results"][0]["endpoint"] == "getDeviceInfo"
+
+
+def test_cli_entrypoint_probe_requires_host() -> None:
+    with pytest.raises(SystemExit):
+        cli_entrypoint(["probe"])
+
+
+def test_cli_entrypoint_run_raises_until_phase_6() -> None:
+    with pytest.raises(NotImplementedError, match="Phase 6"):
+        cli_entrypoint(["run"])
+
+
+def test_cli_entrypoint_no_command_returns_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = cli_entrypoint([])
+
+    assert exit_code == 2
+    # argparse prints help to stderr per our wiring.
+    assert "usage" in capsys.readouterr().err.lower()
+
+
+def test_cli_entrypoint_version_exits_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        cli_entrypoint(["--version"])
+    assert excinfo.value.code == 0
+    assert "ez1-bridge" in capsys.readouterr().out


### PR DESCRIPTION
> **Note:** This PR currently stacks behind [PR #2](https://github.com/baronblk/ez1-mqtt-bridge/pull/2) (Phase 1) since both target \`develop\`. After PR #2 rebase-merges, I will rebase \`feature/phase-2-ez1-adapter\` onto the new \`develop\` and force-push so this PR's diff resolves to phase-2-only.

## Summary

Implements the EZ1 HTTP adapter and the read-only \`probe\` CLI on top of the Phase 1 domain layer. Two atomic commits.

### What's in this PR

- **\`feat(adapters):\`** — \`EZ1Client\` as an async context manager wrapping \`httpx\`. One \`AsyncClient\` instance per bridge run keeps TCP keep-alive on the 45-90 ms WLAN hop. Seven endpoints (5 reads + \`setMaxPower\` + \`setOnOff\`); the inverted on/off semantics are absorbed inside \`set_on_off(on=True/False)\` so callers do not need to know about them. Retry behaviour is an explicit classifier (\`_is_transient\` via \`match\` dispatch) rather than a blanket decorator: timeouts and 5xx retry with exponential backoff (1s / 2s / 4s, capped at 300s, 3 attempts), \`ConnectError\` and 4xx fail fast. Twenty-nine unit tests with \`respx\`.
- **\`feat(cli):\`** — \`python -m ez1_bridge probe --host <ip> [--port N] [--json]\` hits the five read endpoints and reports per-endpoint status. Exit 0 if every endpoint returns \`SUCCESS\`, exit 1 otherwise. Read-only by design: a guard test asserts no write endpoint is ever called. \`--version\` and a placeholder \`run\` subcommand (Phase 6 \`NotImplementedError\`) round out the CLI surface. Twelve tests.

### Quality gates

| Gate | Local | CI |
|---|---|---|
| \`ruff check\` / \`format\` | ✅ | ✅ |
| \`mypy --strict\` (28 files) | ✅ | ✅ |
| \`pytest\` | ✅ 141 tests, 0.46 s | ✅ on 3.12 + 3.13 |
| Coverage overall | ✅ 97.5 % | ✅ |
| Coverage \`domain/\` | ✅ 100 % | ✅ |

## Test plan

- [x] All gates green locally and in CI on \`feature/phase-2-ez1-adapter\`.
- [x] Adapter retry classifier verified per exception type (timeout retried, 5xx retried, 4xx fail-fast, ConnectError fail-fast).
- [x] Read-only invariant of \`probe\` enforced by an explicit guard test.
- [x] Inverted on/off mapping covered in both directions.
- [ ] Reviewer confirms commit history has no AI attribution.
- [ ] After PR #2 merge: rebase \`feature/phase-2-ez1-adapter\` onto fresh \`develop\` so this PR's diff is phase-2-only.