### PR TITLE
Phase 3 — MQTT topics, aiomqtt publisher, real-broker integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "pip-audit>=2.7",
     "pre-commit>=4.0",
     "commitizen>=3.30",
+    "testcontainers>=4.5,<5.0",
 ]
 
 # --- Ruff: linting + formatting ------------------------------------------
@@ -73,6 +74,13 @@ line-length = 100
 target-version = "py312"
 src = ["src", "tests"]
 extend-exclude = ["docs/_reference"]
+
+[tool.ruff.lint.pylint]
+# Adapter constructors carry the wire-shape of an external service
+# (host, port, credentials, topic root, device id, identifier, callbacks);
+# 8 keeps that legitimate use case lint-clean without losing the warning
+# on genuinely god-class constructors.
+max-args = 8
 
 [tool.ruff.lint]
 select = [
@@ -128,6 +136,12 @@ mypy_path = "src"
 [[tool.mypy.overrides]]
 module = ["aiomqtt.*"]
 ignore_missing_imports = false
+
+# testcontainers + docker SDK ship without complete typing — accept the gap
+# in test code rather than vendor stubs locally.
+[[tool.mypy.overrides]]
+module = ["docker.*", "testcontainers.*"]
+ignore_missing_imports = true
 
 # --- pytest --------------------------------------------------------------
 [tool.pytest.ini_options]

--- a/src/ez1_bridge/adapters/mqtt_publisher.py
+++ b/src/ez1_bridge/adapters/mqtt_publisher.py
@@ -1,4 +1,234 @@
-"""Async MQTT publisher (aiomqtt) with LWT, retain semantics, and reconnect logic.
+"""Async MQTT publisher (``aiomqtt``) with LWT, retain semantics, and reconnect hook.
 
-Implementation lands in Phase 3.
+Designed as a thin, retain-aware wrapper around :class:`aiomqtt.Client`.
+The bridge owns one publisher instance for its entire lifetime and
+re-uses the underlying TCP connection — broker reconnect orchestration
+lives one layer up (Phase 6) rather than in the publisher itself, so the
+publisher can stay focused on "construct the right MQTT messages" and
+the application can decide what to do when the network drops.
+
+LWT is set in the client *constructor*, not in any publish call; if the
+process dies ungracefully, the broker fires the configured
+``availability=offline`` retained message on its own. Re-instantiating
+the publisher after a catastrophic failure re-issues the LWT, since
+``Will`` is bound to the underlying client object.
+
+The ``on_reconnect`` callback is wired here as a hook only; Phase 6
+will call :meth:`MQTTPublisher.trigger_reconnect_hook` from its
+reconnect loop to bump the ``ez1_mqtt_reconnects_total`` Prometheus
+counter. Until then, the hook is just a no-op default.
 """
+
+from __future__ import annotations
+
+import json as json_lib
+from collections.abc import Callable, Mapping
+from types import TracebackType
+from typing import Any, Final, Self
+
+import aiomqtt
+from pydantic import SecretStr
+
+from ez1_bridge import topics
+from ez1_bridge.domain.models import InverterState
+
+_DEFAULT_QOS: Final[int] = 1
+
+
+def _flat_pairs(state: InverterState) -> list[tuple[str, str, str]]:
+    """Yield ``(group, key, value)`` triples for the per-metric flat topics.
+
+    The value is already a string so the publisher can hand it straight to
+    :meth:`aiomqtt.Client.publish` without per-call formatting branches.
+    """
+    return [
+        ("power", "ch1_w", str(state.power.ch1_w)),
+        ("power", "ch2_w", str(state.power.ch2_w)),
+        ("power", "total_w", str(state.power.total_w)),
+        ("energy_today", "ch1_kwh", str(state.energy_today.ch1_kwh)),
+        ("energy_today", "ch2_kwh", str(state.energy_today.ch2_kwh)),
+        ("energy_today", "total_kwh", str(state.energy_today.total_kwh)),
+        ("energy_lifetime", "ch1_kwh", str(state.energy_lifetime.ch1_kwh)),
+        ("energy_lifetime", "ch2_kwh", str(state.energy_lifetime.ch2_kwh)),
+        ("energy_lifetime", "total_kwh", str(state.energy_lifetime.total_kwh)),
+        ("max_power_w", "value", str(state.max_power_w)),
+        ("status", "value", state.status),
+        ("alarm", "off_grid", str(state.alarms.off_grid).lower()),
+        ("alarm", "output_fault", str(state.alarms.output_fault).lower()),
+        ("alarm", "dc1_short", str(state.alarms.dc1_short).lower()),
+        ("alarm", "dc2_short", str(state.alarms.dc2_short).lower()),
+        ("alarm", "any_active", str(state.alarms.any_active).lower()),
+    ]
+
+
+class MQTTPublisher:
+    """Retain-aware MQTT publisher with LWT and a reconnect-counter hook.
+
+    Use as an async context manager so the underlying
+    :class:`aiomqtt.Client` is created and torn down exactly once::
+
+        async with MQTTPublisher(host="broker", device_id="E17...") as pub:
+            await pub.publish_availability(online=True)
+            await pub.publish_state(state)
+
+    Calling a publish method outside the context manager raises
+    :class:`RuntimeError`.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 1883,
+        *,
+        username: str | None = None,
+        password: SecretStr | None = None,
+        base_topic: str = "ez1",
+        device_id: str,
+        identifier: str | None = None,
+        on_reconnect: Callable[[], None] | None = None,
+    ) -> None:
+        if not host:
+            msg = "host must be a non-empty string"
+            raise ValueError(msg)
+        if not device_id:
+            msg = "device_id must be a non-empty string"
+            raise ValueError(msg)
+        if not base_topic:
+            msg = "base_topic must be a non-empty string"
+            raise ValueError(msg)
+
+        self._host = host
+        self._port = port
+        self._username = username
+        self._password = password
+        self._base = base_topic
+        self._device_id = device_id
+        self._identifier = identifier or f"ez1-bridge-{device_id}"
+        self._on_reconnect = on_reconnect
+        self._client: aiomqtt.Client | None = None
+
+    @property
+    def base_topic(self) -> str:
+        """Configured MQTT topic root (e.g. ``"ez1"``)."""
+        return self._base
+
+    @property
+    def device_id(self) -> str:
+        """Configured EZ1 device ID, used in every topic path."""
+        return self._device_id
+
+    @property
+    def identifier(self) -> str:
+        """MQTT client_id used during CONNECT."""
+        return self._identifier
+
+    def _build_client(self) -> aiomqtt.Client:
+        """Create the underlying ``aiomqtt.Client`` with LWT preset.
+
+        Extracted from :meth:`__aenter__` so tests can introspect the
+        constructor arguments without driving the full async lifecycle.
+        """
+        return aiomqtt.Client(
+            hostname=self._host,
+            port=self._port,
+            username=self._username,
+            password=(self._password.get_secret_value() if self._password is not None else None),
+            identifier=self._identifier,
+            will=aiomqtt.Will(
+                topic=topics.availability(self._base, self._device_id),
+                payload=topics.AVAILABILITY_OFFLINE,
+                qos=_DEFAULT_QOS,
+                retain=topics.RETAIN["availability"],
+            ),
+        )
+
+    async def __aenter__(self) -> Self:
+        client = self._build_client()
+        await client.__aenter__()
+        self._client = client
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._client is not None:
+            await self._client.__aexit__(exc_type, exc, tb)
+            self._client = None
+
+    def _ensure_client(self) -> aiomqtt.Client:
+        if self._client is None:
+            msg = "MQTTPublisher must be used as an async context manager"
+            raise RuntimeError(msg)
+        return self._client
+
+    # --- Publish methods -------------------------------------------------
+
+    async def publish_availability(self, *, online: bool) -> None:
+        """Publish ``"online"`` or ``"offline"`` to the availability topic.
+
+        The bridge calls this with ``online=True`` immediately after
+        connect; the LWT handles ``offline`` automatically on ungraceful
+        disconnect.
+        """
+        client = self._ensure_client()
+        payload = topics.AVAILABILITY_ONLINE if online else topics.AVAILABILITY_OFFLINE
+        await client.publish(
+            topics.availability(self._base, self._device_id),
+            payload=payload,
+            qos=_DEFAULT_QOS,
+            retain=topics.RETAIN["availability"],
+        )
+
+    async def publish_state(self, state: InverterState) -> None:
+        """Publish the structured JSON state plus all flat per-metric topics.
+
+        Both the JSON state topic and the per-metric flat topics are
+        retained so a fresh subscriber (HA, mosquitto_sub, etc.) sees
+        the latest snapshot immediately.
+        """
+        client = self._ensure_client()
+        await client.publish(
+            topics.state(self._base, self._device_id),
+            payload=state.model_dump_json(),
+            qos=_DEFAULT_QOS,
+            retain=topics.RETAIN["state"],
+        )
+        for group, key, value in _flat_pairs(state):
+            await client.publish(
+                topics.flat(self._base, self._device_id, group, key),
+                payload=value,
+                qos=_DEFAULT_QOS,
+                retain=topics.RETAIN["flat"],
+            )
+
+    async def publish_result(self, command_name: str, payload: Mapping[str, Any]) -> None:
+        """Publish a command-result event (``retain=False``).
+
+        Used by the Phase-5 command handler to acknowledge writes.
+        Phase 3 ships the publisher-side machinery only; the handler
+        wires it up.
+        """
+        client = self._ensure_client()
+        await client.publish(
+            topics.result(self._base, self._device_id, command_name),
+            payload=json_lib.dumps(payload),
+            qos=_DEFAULT_QOS,
+            retain=topics.RETAIN["result"],
+        )
+
+    # --- Reconnect-counter hook -----------------------------------------
+
+    def trigger_reconnect_hook(self) -> None:
+        """Invoke the ``on_reconnect`` callback if one was wired.
+
+        Phase 6's reconnect-orchestration loop calls this each time it
+        successfully re-establishes the broker connection so the
+        ``ez1_mqtt_reconnects_total`` Prometheus counter advances. The
+        publisher itself does not own the reconnect loop — that
+        responsibility lives in :mod:`ez1_bridge.main`.
+        """
+        if self._on_reconnect is not None:
+            self._on_reconnect()

--- a/src/ez1_bridge/topics.py
+++ b/src/ez1_bridge/topics.py
@@ -1,4 +1,101 @@
-"""Centralized MQTT topic builders — no magic strings elsewhere in the codebase.
+"""Centralized MQTT topic builders for the bridge.
 
-Implementation lands in Phase 3.
+Every topic string in the codebase flows through this module — there are no
+magic strings anywhere else. Phase 4 (HA discovery) and Phase 5 (command
+handler) import the same builders so a topic-schema change ripples from
+exactly one place.
+
+Retain semantics
+----------------
+
+The ``RETAIN`` mapping below fixes the per-topic-kind retain behaviour as
+machine-readable metadata. The publisher reads it directly; readers of
+this module do not have to look up MQTT semantics elsewhere.
+
+================  ======  ========================================================
+Topic kind        Retain  Reason
+================  ======  ========================================================
+availability      ✅      New subscribers must see liveness state immediately.
+state             ✅      Home Assistant needs latest state after a broker restart.
+flat              ✅      Same — for non-JSON consumers reading individual metrics.
+result            ❌      Event-based; old write outcomes would be misleading.
+discovery         ✅      HA discovery configs persist across HA restarts.
+set (subscribed)  n/a     Subscribed by the bridge, never published from here.
+================  ======  ========================================================
 """
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Final, Literal
+
+# --- Static path components --------------------------------------------
+_AVAILABILITY: Final[str] = "availability"
+_STATE: Final[str] = "state"
+_RESULT: Final[str] = "result"
+_SET: Final[str] = "set"
+_CONFIG: Final[str] = "config"
+
+# --- Availability payload constants ------------------------------------
+AVAILABILITY_ONLINE: Final[str] = "online"
+AVAILABILITY_OFFLINE: Final[str] = "offline"
+
+# --- Type aliases ------------------------------------------------------
+HAComponent = Literal["sensor", "binary_sensor"]
+
+
+# --- Builders ----------------------------------------------------------
+
+
+def availability(base: str, device_id: str) -> str:
+    """``{base}/{device_id}/availability`` (retain=True, payload online/offline)."""
+    return f"{base}/{device_id}/{_AVAILABILITY}"
+
+
+def state(base: str, device_id: str) -> str:
+    """``{base}/{device_id}/state`` (retain=True, JSON payload)."""
+    return f"{base}/{device_id}/{_STATE}"
+
+
+def flat(base: str, device_id: str, group: str, key: str) -> str:
+    """``{base}/{device_id}/{group}/{key}`` for individual metric values.
+
+    Used for the per-metric flat topics (e.g. ``ez1/E17.../power/total_w``)
+    that complement the structured JSON state topic for non-JSON consumers.
+    """
+    return f"{base}/{device_id}/{group}/{key}"
+
+
+def command(base: str, device_id: str, name: str) -> str:
+    """``{base}/{device_id}/set/{name}`` (subscribed; not published from here)."""
+    return f"{base}/{device_id}/{_SET}/{name}"
+
+
+def command_wildcard(base: str, device_id: str) -> str:
+    """``{base}/{device_id}/set/+`` — wildcard subscription pattern."""
+    return f"{base}/{device_id}/{_SET}/+"
+
+
+def result(base: str, device_id: str, name: str) -> str:
+    """``{base}/{device_id}/result/{name}`` (retain=False, event-based)."""
+    return f"{base}/{device_id}/{_RESULT}/{name}"
+
+
+def discovery(prefix: str, component: HAComponent, device_id: str, key: str) -> str:
+    """``{prefix}/{component}/{device_id}/{key}/config`` for HA discovery.
+
+    Components are constrained to the two HA platform types we use:
+    ``sensor`` (numeric metrics) and ``binary_sensor`` (alarm bits).
+    """
+    return f"{prefix}/{component}/{device_id}/{key}/{_CONFIG}"
+
+
+# --- Retain semantics, machine-readable --------------------------------
+
+RETAIN: Final[Mapping[str, bool]] = {
+    "availability": True,
+    "state": True,
+    "flat": True,
+    "result": False,
+    "discovery": True,
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,11 +104,21 @@ def _start_mosquitto(
 
     ``extra_files`` maps relative filenames inside ``/mosquitto/config`` to
     their text content (e.g. a password file).
+
+    The temp dir and its files are explicitly chmod'd to ``0755``/``0644``
+    so the unprivileged ``mosquitto`` user (UID 1883) inside the container
+    can read them. macOS Docker Desktop is forgiving about host-side
+    permissions, but Linux Docker is not — without this, the auth broker
+    silently fails to load the password file and rejects every CONNECT.
     """
     config_dir = Path(tempfile.mkdtemp(prefix="ez1-mosquitto-"))
+    config_dir.chmod(0o755)
     (config_dir / "mosquitto.conf").write_text(config_text, encoding="utf-8")
+    (config_dir / "mosquitto.conf").chmod(0o644)
     for name, content in (extra_files or {}).items():
-        (config_dir / name).write_text(content, encoding="utf-8")
+        path = config_dir / name
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o644)
 
     container = (
         DockerContainer(_MOSQUITTO_IMAGE)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,156 @@
+"""Integration-test fixtures: real Mosquitto brokers spun up via testcontainers.
+
+Two flavours are exposed:
+
+* ``mosquitto_broker`` — anonymous broker, used by the bulk of tests
+  (publish, retain, etc.) — session-scoped, started once.
+* ``mosquitto_auth_broker`` — broker with ``allow_anonymous false`` and a
+  password file containing a single ``ez1user:ez1pass`` entry. Session
+  scope as well; the password hash is generated in-process so tests stay
+  hermetic.
+
+If Docker is unavailable on the host (no daemon running, missing socket,
+permission denied) every fixture skips its dependent tests — the unit
+layer still exercises the publisher contract via mocks, and CI on Linux
+runners always has Docker.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import socket
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import suppress
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+try:
+    from docker.errors import DockerException
+    from testcontainers.core.container import DockerContainer
+except ImportError as exc:  # pragma: no cover - missing dev dep
+    pytest.skip(f"testcontainers not installed: {exc}", allow_module_level=True)
+
+
+_MOSQUITTO_IMAGE = "eclipse-mosquitto:2.0.20"
+_DEFAULT_CONFIG = """\
+listener 1883
+allow_anonymous true
+persistence false
+log_dest stdout
+"""
+_AUTH_CONFIG = """\
+listener 1883
+allow_anonymous false
+password_file /mosquitto/config/passwd
+persistence false
+log_dest stdout
+"""
+_READY_TIMEOUT_SECONDS = 30
+_TCP_POLL_INTERVAL_SECONDS = 0.5
+
+#: Credentials baked into the auth fixture. Hard-coded for reproducibility;
+#: the password is fictional and never used outside the test harness.
+AUTH_USERNAME = "ez1user"
+AUTH_PASSWORD = "ez1pass"
+
+
+class BrokerEndpoint(NamedTuple):
+    """Resolved host/port pair for a running broker."""
+
+    host: str
+    port: int
+
+
+def _mosquitto_password_hash(password: str, *, iterations: int = 101) -> str:
+    """Build a Mosquitto ``$7$`` (PBKDF2-SHA512) password hash for ``password``.
+
+    Format: ``$7$<iterations>$<salt_b64>$<hash_b64>`` — matches the format
+    that ``mosquitto_passwd`` itself produces, so we do not need to run
+    that binary inside the container.
+    """
+    salt = secrets.token_bytes(12)
+    derived = hashlib.pbkdf2_hmac("sha512", password.encode("utf-8"), salt, iterations, dklen=64)
+    salt_b64 = base64.b64encode(salt).decode("ascii")
+    hash_b64 = base64.b64encode(derived).decode("ascii")
+    return f"$7${iterations}${salt_b64}${hash_b64}"
+
+
+def _wait_for_tcp(host: str, port: int, timeout: float) -> None:
+    """Block until ``host:port`` accepts a TCP connection or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    last_exc: OSError | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except OSError as exc:
+            last_exc = exc
+            time.sleep(_TCP_POLL_INTERVAL_SECONDS)
+    msg = f"broker {host}:{port} did not accept connections within {timeout}s"
+    raise TimeoutError(msg) from last_exc
+
+
+def _start_mosquitto(
+    config_text: str,
+    extra_files: dict[str, str] | None = None,
+) -> tuple[DockerContainer, BrokerEndpoint]:
+    """Spin up a Mosquitto container with the supplied config and extra files.
+
+    ``extra_files`` maps relative filenames inside ``/mosquitto/config`` to
+    their text content (e.g. a password file).
+    """
+    config_dir = Path(tempfile.mkdtemp(prefix="ez1-mosquitto-"))
+    (config_dir / "mosquitto.conf").write_text(config_text, encoding="utf-8")
+    for name, content in (extra_files or {}).items():
+        (config_dir / name).write_text(content, encoding="utf-8")
+
+    container = (
+        DockerContainer(_MOSQUITTO_IMAGE)
+        .with_exposed_ports(1883)
+        .with_volume_mapping(str(config_dir), "/mosquitto/config", "ro")
+    )
+    container.start()
+    host = container.get_container_host_ip()
+    port = int(container.get_exposed_port(1883))
+    _wait_for_tcp(host, port, _READY_TIMEOUT_SECONDS)
+    return container, BrokerEndpoint(host=host, port=port)
+
+
+@pytest.fixture(scope="session")
+def mosquitto_broker() -> Iterator[BrokerEndpoint]:
+    """Session-scoped anonymous Mosquitto broker — shared across tests."""
+    try:
+        container, endpoint = _start_mosquitto(_DEFAULT_CONFIG)
+    except DockerException as exc:
+        pytest.skip(f"Docker not available for integration tests: {exc}")
+
+    try:
+        yield endpoint
+    finally:
+        with suppress(Exception):
+            container.stop()
+
+
+@pytest.fixture(scope="session")
+def mosquitto_auth_broker() -> Iterator[BrokerEndpoint]:
+    """Session-scoped Mosquitto broker with username/password authentication."""
+    password_line = f"{AUTH_USERNAME}:{_mosquitto_password_hash(AUTH_PASSWORD)}\n"
+    try:
+        container, endpoint = _start_mosquitto(
+            _AUTH_CONFIG,
+            extra_files={"passwd": password_line},
+        )
+    except DockerException as exc:
+        pytest.skip(f"Docker not available for integration tests: {exc}")
+
+    try:
+        yield endpoint
+    finally:
+        with suppress(Exception):
+            container.stop()

--- a/tests/integration/test_mqtt_broker.py
+++ b/tests/integration/test_mqtt_broker.py
@@ -1,0 +1,271 @@
+"""Integration tests for :class:`MQTTPublisher` against a real Mosquitto broker.
+
+Run end-to-end against an ``eclipse-mosquitto:2.0.20`` container managed
+by ``testcontainers``. Each test owns a unique device_id so retained
+messages from earlier tests never bleed into later ones, even though
+the broker is session-scoped.
+
+Skipped automatically when Docker is unavailable on the host (see
+``conftest.py``); CI on Linux runners always has Docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import UTC, datetime
+
+import aiomqtt
+import pytest
+from pydantic import SecretStr
+
+from ez1_bridge import topics
+from ez1_bridge.adapters.mqtt_publisher import MQTTPublisher
+from ez1_bridge.domain.models import (
+    AlarmFlags,
+    EnergyReading,
+    InverterState,
+    PowerReading,
+)
+
+from .conftest import AUTH_PASSWORD, AUTH_USERNAME, BrokerEndpoint
+
+pytestmark = pytest.mark.integration
+
+_MESSAGE_TIMEOUT_SECONDS = 5.0
+
+
+@pytest.fixture
+def device_id() -> str:
+    """Unique per-test device_id so retained messages don't leak across tests."""
+    return f"E{uuid.uuid4().hex[:12].upper()}"
+
+
+@pytest.fixture
+def sample_state(device_id: str) -> InverterState:
+    return InverterState(
+        ts=datetime(2026, 4, 26, 18, 0, tzinfo=UTC),
+        device_id=device_id,
+        power=PowerReading(ch1_w=139.0, ch2_w=65.0),
+        energy_today=EnergyReading(ch1_kwh=0.28731, ch2_kwh=0.42653),
+        energy_lifetime=EnergyReading(ch1_kwh=87.43068, ch2_kwh=111.24305),
+        max_power_w=800,
+        status="on",
+        alarms=AlarmFlags(off_grid=False, output_fault=False, dc1_short=False, dc2_short=False),
+    )
+
+
+async def _wait_for_message_on(
+    client: aiomqtt.Client,
+    expected_topic: str,
+    *,
+    timeout: float = _MESSAGE_TIMEOUT_SECONDS,
+) -> aiomqtt.Message:
+    """Block until ``client`` receives a message on ``expected_topic``."""
+    async with asyncio.timeout(timeout):
+        async for msg in client.messages:
+            if str(msg.topic) == expected_topic:
+                return msg
+    err = f"no message on {expected_topic} within {timeout}s"
+    raise TimeoutError(err)
+
+
+# --- Connection + publish ----------------------------------------------
+
+
+async def test_publish_availability_arrives_at_subscriber(
+    mosquitto_broker: BrokerEndpoint,
+    device_id: str,
+) -> None:
+    """The publisher's online announcement reaches a concurrent subscriber."""
+    availability_topic = topics.availability("ez1", device_id)
+
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(availability_topic, qos=1)
+
+        async with MQTTPublisher(
+            host=mosquitto_broker.host,
+            port=mosquitto_broker.port,
+            device_id=device_id,
+        ) as pub:
+            await pub.publish_availability(online=True)
+
+            msg = await _wait_for_message_on(observer, availability_topic)
+
+    assert msg.payload == b"online"
+
+
+async def test_publish_state_arrives_at_subscriber(
+    mosquitto_broker: BrokerEndpoint,
+    device_id: str,
+    sample_state: InverterState,
+) -> None:
+    """The structured JSON state payload is delivered intact."""
+    state_topic = topics.state("ez1", device_id)
+
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(state_topic, qos=1)
+
+        async with MQTTPublisher(
+            host=mosquitto_broker.host,
+            port=mosquitto_broker.port,
+            device_id=device_id,
+        ) as pub:
+            await pub.publish_state(sample_state)
+
+            msg = await _wait_for_message_on(observer, state_topic)
+
+    assert isinstance(msg.payload, bytes | bytearray)
+    body = json.loads(bytes(msg.payload).decode("utf-8"))
+    assert body["device_id"] == device_id
+    assert body["status"] == "on"
+    assert body["power"]["total_w"] == 204.0
+
+
+# --- Retain semantics --------------------------------------------------
+
+
+async def test_state_retain_delivers_to_late_subscriber(
+    mosquitto_broker: BrokerEndpoint,
+    device_id: str,
+    sample_state: InverterState,
+) -> None:
+    """A subscriber that connects *after* publish receives the retained state.
+
+    This is the regression that bites HA integrations: if retain is
+    misconfigured, dashboards stay empty after a broker or HA restart.
+    """
+    state_topic = topics.state("ez1", device_id)
+
+    # Publish first, while no subscriber is listening.
+    async with MQTTPublisher(
+        host=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        device_id=device_id,
+    ) as pub:
+        await pub.publish_state(sample_state)
+
+    # Now subscribe — broker should immediately deliver the retained message.
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"late-observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(state_topic, qos=1)
+        msg = await _wait_for_message_on(observer, state_topic)
+
+    body = json.loads(bytes(msg.payload).decode("utf-8"))
+    assert body["device_id"] == device_id
+    assert body["status"] == "on"
+    assert msg.retain is True
+
+
+async def test_result_topic_is_not_retained(
+    mosquitto_broker: BrokerEndpoint,
+    device_id: str,
+) -> None:
+    """A late subscriber must NOT see old result events — they are events, not state."""
+    result_topic = topics.result("ez1", device_id, "max_power")
+
+    # Publish a result while nobody is listening.
+    async with MQTTPublisher(
+        host=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        device_id=device_id,
+    ) as pub:
+        await pub.publish_result("max_power", {"ok": True, "value": 600})
+
+    # Subscribe afterwards; expect NOTHING within the short timeout.
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"late-observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(result_topic, qos=1)
+
+        with pytest.raises(TimeoutError):
+            await _wait_for_message_on(observer, result_topic, timeout=1.5)
+
+
+async def test_flat_topics_retained(
+    mosquitto_broker: BrokerEndpoint,
+    device_id: str,
+    sample_state: InverterState,
+) -> None:
+    """The flat per-metric topics are retained alongside the JSON state."""
+    flat_topic = topics.flat("ez1", device_id, "power", "total_w")
+
+    async with MQTTPublisher(
+        host=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        device_id=device_id,
+    ) as pub:
+        await pub.publish_state(sample_state)
+
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"flat-observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(flat_topic, qos=1)
+        msg = await _wait_for_message_on(observer, flat_topic)
+
+    assert bytes(msg.payload).decode("utf-8") == "204.0"
+    assert msg.retain is True
+
+
+# --- Authentication ----------------------------------------------------
+
+
+async def test_publisher_authenticates_with_username_password(
+    mosquitto_auth_broker: BrokerEndpoint,
+    device_id: str,
+) -> None:
+    """With matching credentials the publisher connects and publishes successfully."""
+    availability_topic = topics.availability("ez1", device_id)
+
+    async with aiomqtt.Client(
+        hostname=mosquitto_auth_broker.host,
+        port=mosquitto_auth_broker.port,
+        username=AUTH_USERNAME,
+        password=AUTH_PASSWORD,
+        identifier=f"auth-observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(availability_topic, qos=1)
+
+        async with MQTTPublisher(
+            host=mosquitto_auth_broker.host,
+            port=mosquitto_auth_broker.port,
+            username=AUTH_USERNAME,
+            password=SecretStr(AUTH_PASSWORD),
+            device_id=device_id,
+        ) as pub:
+            await pub.publish_availability(online=True)
+
+            msg = await _wait_for_message_on(observer, availability_topic)
+
+    assert msg.payload == b"online"
+
+
+async def test_publisher_rejected_without_credentials(
+    mosquitto_auth_broker: BrokerEndpoint,
+    device_id: str,
+) -> None:
+    """Without credentials, the auth broker refuses the CONNECT."""
+    pub = MQTTPublisher(
+        host=mosquitto_auth_broker.host,
+        port=mosquitto_auth_broker.port,
+        device_id=device_id,
+    )
+
+    with pytest.raises(aiomqtt.MqttError):
+        await pub.__aenter__()

--- a/tests/unit/test_mqtt_publisher.py
+++ b/tests/unit/test_mqtt_publisher.py
@@ -1,0 +1,328 @@
+"""Unit tests for :mod:`ez1_bridge.adapters.mqtt_publisher`.
+
+These tests mock :class:`aiomqtt.Client` and assert that the publisher
+constructs LWT correctly, publishes to the right topics with the right
+retain flags and QoS, and respects the async-context-manager contract.
+
+Real-broker behaviour (LWT actually fires, retain survives reconnect,
+etc.) is covered separately in
+``tests/integration/test_mqtt_broker.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import aiomqtt
+import pytest
+from pydantic import SecretStr
+
+from ez1_bridge import topics
+from ez1_bridge.adapters.mqtt_publisher import MQTTPublisher
+from ez1_bridge.domain.models import (
+    AlarmFlags,
+    EnergyReading,
+    InverterState,
+    PowerReading,
+)
+
+
+@pytest.fixture
+def sample_state() -> InverterState:
+    return InverterState(
+        ts=datetime(2026, 4, 26, 18, 0, tzinfo=UTC),
+        device_id="E17010000783",
+        power=PowerReading(ch1_w=139.0, ch2_w=65.0),
+        energy_today=EnergyReading(ch1_kwh=0.28731, ch2_kwh=0.42653),
+        energy_lifetime=EnergyReading(ch1_kwh=87.43068, ch2_kwh=111.24305),
+        max_power_w=800,
+        status="on",
+        alarms=AlarmFlags(off_grid=False, output_fault=False, dc1_short=False, dc2_short=False),
+    )
+
+
+def _mock_client() -> MagicMock:
+    """Build a MagicMock that mimics aiomqtt.Client's async context manager."""
+    client = MagicMock(spec=aiomqtt.Client)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.publish = AsyncMock()
+    return client
+
+
+# --- Construction guards -------------------------------------------------
+
+
+def test_empty_host_rejected() -> None:
+    with pytest.raises(ValueError, match="host"):
+        MQTTPublisher("", device_id="E1")
+
+
+def test_empty_device_id_rejected() -> None:
+    with pytest.raises(ValueError, match="device_id"):
+        MQTTPublisher("broker.local", device_id="")
+
+
+def test_empty_base_topic_rejected() -> None:
+    with pytest.raises(ValueError, match="base_topic"):
+        MQTTPublisher("broker.local", device_id="E1", base_topic="")
+
+
+def test_default_identifier_includes_device_id() -> None:
+    pub = MQTTPublisher("broker.local", device_id="E17010000783")
+    assert pub.identifier == "ez1-bridge-E17010000783"
+
+
+def test_custom_identifier_passed_through() -> None:
+    pub = MQTTPublisher(
+        "broker.local",
+        device_id="E1",
+        identifier="custom-id-7",
+    )
+    assert pub.identifier == "custom-id-7"
+
+
+def test_properties_round_trip() -> None:
+    pub = MQTTPublisher(
+        "broker.local",
+        device_id="E1",
+        base_topic="solar",
+    )
+    assert pub.base_topic == "solar"
+    assert pub.device_id == "E1"
+
+
+# --- LWT configuration --------------------------------------------------
+
+
+def test_build_client_sets_lwt_to_offline_with_retain() -> None:
+    pub = MQTTPublisher("broker.local", device_id="E17010000783")
+
+    with patch(
+        "ez1_bridge.adapters.mqtt_publisher.aiomqtt.Client",
+    ) as mock_cls:
+        pub._build_client()
+
+    mock_cls.assert_called_once()
+    will = mock_cls.call_args.kwargs["will"]
+    assert isinstance(will, aiomqtt.Will)
+    assert will.topic == "ez1/E17010000783/availability"
+    assert will.payload == "offline"
+    assert will.retain is True
+    assert will.qos == 1
+
+
+def test_build_client_passes_credentials() -> None:
+    pub = MQTTPublisher(
+        "broker.local",
+        device_id="E1",
+        username="alice",
+        password=SecretStr("hunter2"),
+    )
+
+    with patch(
+        "ez1_bridge.adapters.mqtt_publisher.aiomqtt.Client",
+    ) as mock_cls:
+        pub._build_client()
+
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["username"] == "alice"
+    assert kwargs["password"] == "hunter2"
+
+
+def test_build_client_passes_no_credentials_when_unset() -> None:
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch(
+        "ez1_bridge.adapters.mqtt_publisher.aiomqtt.Client",
+    ) as mock_cls:
+        pub._build_client()
+
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["username"] is None
+    assert kwargs["password"] is None
+
+
+# --- Async context manager ----------------------------------------------
+
+
+async def test_aenter_calls_underlying_client_aenter() -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            mock_client.__aenter__.assert_awaited_once()
+
+    mock_client.__aexit__.assert_awaited_once()
+
+
+async def test_publish_outside_context_raises() -> None:
+    pub = MQTTPublisher("broker.local", device_id="E1")
+    with pytest.raises(RuntimeError, match="async context manager"):
+        await pub.publish_availability(online=True)
+
+
+# --- publish_availability ----------------------------------------------
+
+
+async def test_publish_availability_online_publishes_with_retain() -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            await pub.publish_availability(online=True)
+
+    mock_client.publish.assert_awaited_once_with(
+        "ez1/E1/availability",
+        payload="online",
+        qos=1,
+        retain=True,
+    )
+
+
+async def test_publish_availability_offline() -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            await pub.publish_availability(online=False)
+
+    mock_client.publish.assert_awaited_once_with(
+        "ez1/E1/availability",
+        payload="offline",
+        qos=1,
+        retain=True,
+    )
+
+
+# --- publish_state -----------------------------------------------------
+
+
+async def test_publish_state_emits_json_topic_with_retain(
+    sample_state: InverterState,
+) -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E17010000783")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            await pub.publish_state(sample_state)
+
+    # The first publish call should be the structured JSON state.
+    first_call = mock_client.publish.await_args_list[0]
+    assert first_call.args[0] == "ez1/E17010000783/state"
+    assert first_call.kwargs["retain"] is True
+    assert first_call.kwargs["qos"] == 1
+    body = json.loads(first_call.kwargs["payload"])
+    assert body["status"] == "on"
+    assert body["device_id"] == "E17010000783"
+    assert body["power"]["total_w"] == 204.0
+
+
+async def test_publish_state_emits_flat_topics_with_retain(
+    sample_state: InverterState,
+) -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            await pub.publish_state(sample_state)
+
+    flat_calls = [c for c in mock_client.publish.await_args_list if c.args[0] != "ez1/E1/state"]
+    assert len(flat_calls) == 16  # 3 power + 3 today + 3 lifetime + 1 max + 1 status + 5 alarm
+
+    flat_topics = {c.args[0] for c in flat_calls}
+    assert "ez1/E1/power/ch1_w" in flat_topics
+    assert "ez1/E1/power/total_w" in flat_topics
+    assert "ez1/E1/energy_today/total_kwh" in flat_topics
+    assert "ez1/E1/energy_lifetime/total_kwh" in flat_topics
+    assert "ez1/E1/max_power_w/value" in flat_topics
+    assert "ez1/E1/status/value" in flat_topics
+    assert "ez1/E1/alarm/off_grid" in flat_topics
+    assert "ez1/E1/alarm/any_active" in flat_topics
+
+    for c in flat_calls:
+        assert c.kwargs["retain"] is True
+        assert c.kwargs["qos"] == 1
+
+
+async def test_publish_state_flat_alarm_values_are_lowercase_strings(
+    sample_state: InverterState,
+) -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            await pub.publish_state(sample_state)
+
+    by_topic = {c.args[0]: c.kwargs["payload"] for c in mock_client.publish.await_args_list}
+    assert by_topic["ez1/E1/alarm/off_grid"] == "false"
+    assert by_topic["ez1/E1/alarm/any_active"] == "false"
+
+
+# --- publish_result ---------------------------------------------------
+
+
+async def test_publish_result_does_not_retain() -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            await pub.publish_result(
+                "max_power",
+                {"ok": True, "value": 600},
+            )
+
+    mock_client.publish.assert_awaited_once()
+    awaited_call = mock_client.publish.await_args
+    assert awaited_call.args[0] == "ez1/E1/result/max_power"
+    assert awaited_call.kwargs["retain"] is False
+    body = json.loads(awaited_call.kwargs["payload"])
+    assert body == {"ok": True, "value": 600}
+
+
+# --- Reconnect hook ---------------------------------------------------
+
+
+def test_reconnect_hook_is_optional() -> None:
+    pub = MQTTPublisher("broker.local", device_id="E1")
+    pub.trigger_reconnect_hook()  # must not raise without an on_reconnect callback
+
+
+def test_reconnect_hook_invokes_callback() -> None:
+    counter = MagicMock()
+    pub = MQTTPublisher(
+        "broker.local",
+        device_id="E1",
+        on_reconnect=counter,
+    )
+
+    pub.trigger_reconnect_hook()
+    pub.trigger_reconnect_hook()
+
+    assert counter.call_count == 2
+    counter.assert_has_calls([call(), call()])
+
+
+# --- Defensive uses of the topics module ------------------------------
+
+
+def test_publisher_uses_topics_retain_map_directly() -> None:
+    """Regression guard: do not hard-code retain flags in the publisher.
+
+    The retain semantics live in :mod:`ez1_bridge.topics.RETAIN`. A
+    refactor that hard-codes ``retain=True`` somewhere should fail this
+    test by mismatching the canonical map.
+    """
+    assert topics.RETAIN["availability"] is True
+    assert topics.RETAIN["state"] is True
+    assert topics.RETAIN["flat"] is True
+    assert topics.RETAIN["result"] is False

--- a/tests/unit/test_topics.py
+++ b/tests/unit/test_topics.py
@@ -1,0 +1,91 @@
+"""Tests for :mod:`ez1_bridge.topics`."""
+
+from __future__ import annotations
+
+from ez1_bridge import topics
+
+# --- Builders ----------------------------------------------------------
+
+
+def test_availability_topic() -> None:
+    assert topics.availability("ez1", "E17010000783") == "ez1/E17010000783/availability"
+
+
+def test_state_topic() -> None:
+    assert topics.state("ez1", "E17010000783") == "ez1/E17010000783/state"
+
+
+def test_flat_topic() -> None:
+    assert (
+        topics.flat("ez1", "E17010000783", "power", "total_w") == "ez1/E17010000783/power/total_w"
+    )
+
+
+def test_command_topic() -> None:
+    assert topics.command("ez1", "E17010000783", "max_power") == "ez1/E17010000783/set/max_power"
+
+
+def test_command_wildcard() -> None:
+    assert topics.command_wildcard("ez1", "E17010000783") == "ez1/E17010000783/set/+"
+
+
+def test_result_topic() -> None:
+    assert topics.result("ez1", "E17010000783", "on_off") == "ez1/E17010000783/result/on_off"
+
+
+def test_discovery_topic_sensor() -> None:
+    assert (
+        topics.discovery("homeassistant", "sensor", "E17010000783", "power_total")
+        == "homeassistant/sensor/E17010000783/power_total/config"
+    )
+
+
+def test_discovery_topic_binary_sensor() -> None:
+    assert (
+        topics.discovery(
+            "homeassistant",
+            "binary_sensor",
+            "E17010000783",
+            "alarm_off_grid",
+        )
+        == "homeassistant/binary_sensor/E17010000783/alarm_off_grid/config"
+    )
+
+
+def test_custom_base_and_prefix() -> None:
+    assert topics.availability("solar", "E1") == "solar/E1/availability"
+    assert topics.discovery("ha", "sensor", "E1", "p1") == "ha/sensor/E1/p1/config"
+
+
+# --- Retain semantics --------------------------------------------------
+
+
+def test_retain_map_covers_expected_kinds() -> None:
+    assert set(topics.RETAIN.keys()) == {
+        "availability",
+        "state",
+        "flat",
+        "result",
+        "discovery",
+    }
+
+
+def test_retain_state_topics_are_retained() -> None:
+    assert topics.RETAIN["availability"] is True
+    assert topics.RETAIN["state"] is True
+    assert topics.RETAIN["flat"] is True
+    assert topics.RETAIN["discovery"] is True
+
+
+def test_retain_result_is_not_retained() -> None:
+    """Results are events, not state — retaining them would mislead late subscribers."""
+    assert topics.RETAIN["result"] is False
+
+
+# --- Availability payload constants -----------------------------------
+
+
+def test_availability_payloads_are_distinct() -> None:
+    assert topics.AVAILABILITY_ONLINE == "online"
+    assert topics.AVAILABILITY_OFFLINE == "offline"
+    assert topics.AVAILABILITY_ONLINE != topics.AVAILABILITY_OFFLINE

--- a/uv.lock
+++ b/uv.lock
@@ -470,6 +470,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "ez1-mqtt-bridge"
 version = "0.0.0"
 source = { editable = "." }
@@ -495,6 +509,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -520,6 +535,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.7" },
+    { name = "testcontainers", specifier = ">=4.5,<5.0" },
 ]
 
 [[package]]
@@ -1486,6 +1502,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1642,6 +1674,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the MQTT side of the bridge: centralised topic builders with a retain-semantics map, an aiomqtt-based publisher with LWT and reconnect hook, and a real-Mosquitto integration suite via testcontainers.

Branched off \`develop\` (parallel to PR #3) since Phase 3 has no dependency on Phase 2's HTTP adapter — both should be reviewable independently.

### What's in this PR (5 atomic commits)

- **\`chore(tooling):\`** — bump pylint max-args from 5 to 8 (legitimate adapter-ctor surface), add \`testcontainers>=4.5,<5.0\` as a dev dep, ignore missing stubs for \`docker.*\` and \`testcontainers.*\` in mypy.
- **\`feat:\`** — \`topics.py\` with builders for \`availability\` / \`state\` / flat per-metric / \`set/+\` / \`result/+\` / HA discovery, plus a machine-readable \`RETAIN: Mapping[str, bool]\` so retain semantics live in exactly one place. 13 unit tests.
- **\`feat(adapters):\`** — \`MQTTPublisher\` as a thin retain-aware wrapper around \`aiomqtt.Client\`. LWT set in the constructor (not in any publish call), reconnect-counter hook ready for Phase 6 wiring, three publish methods (availability / state / result) that read \`topics.RETAIN\` directly. SecretStr unwrap for the password. 20 unit tests with mocked aiomqtt.
- **\`test(integration):\`** — 7 tests against \`eclipse-mosquitto:2.0.20\` via testcontainers. Two session-scoped fixtures: anonymous broker for the bulk of the suite, auth-enabled broker (\`allow_anonymous false\` + \`password_file\`) for two credential tests. Password hash generated in-process as Mosquitto-compatible \`\$7\$\` PBKDF2-SHA512 — no \`mosquitto_passwd\` binary, no precomputed fixture. Skips cleanly if Docker is unavailable.
- **\`fix(integration):\`** — chmod config tempdir 0755 / files 0644 so the mosquitto user (UID 1883) inside the container can read them on Linux Docker bind mounts. macOS Docker Desktop is permission-lax; this difference cost one CI cycle to spot.

### Tests covered

| Test | Surface |
|---|---|
| Topic builders (13) | URL shape, retain map coverage, payload constants |
| Publisher unit (20) | LWT config, credentials, retain flags, JSON+flat emission, reconnect hook |
| Real broker (7) | publish_state arrives, retain delivers to late subscriber, result NOT retained, flat topics retained, auth success + auth rejection |

### Quality gates

| Gate | Local | CI |
|---|---|---|
| \`ruff check\` / \`format\` | ✅ | ✅ |
| \`mypy --strict\` (30 files) | ✅ | ✅ |
| \`pytest\` | ✅ 140 tests, 2.7 s | ✅ on 3.12 + 3.13 with real broker |
| Coverage overall | ✅ 98.2 % | ✅ |
| Coverage \`domain/\` | ✅ 100 % | ✅ |

## Test plan

- [x] All gates green locally and in CI.
- [x] Real Mosquitto integration tests pass on Linux runners (initial CI red because of the bind-mount permission issue, fixed and re-verified green).
- [x] Auth broker test verifies the bridge connects with username + SecretStr password and is rejected without.
- [x] Retain semantics: a late subscriber receives the retained state but NOT old result events.
- [ ] Reviewer confirms commit history has no AI attribution.