### PR TITLE
Phase 5 — MQTT command handler with verify, three-layer validation, and TaskGroup cancellation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,13 @@ EZ1_BRIDGE_EZ1_PORT=8050
 EZ1_BRIDGE_POLL_INTERVAL=20
 EZ1_BRIDGE_REQUEST_TIMEOUT=5
 
+# --- Commands -------------------------------------------------------------
+# After a setMaxPower write, re-read getMaxPower (after ~2s) and publish
+# verify_mismatch on the result topic if the inverter did not accept the
+# value. Set to "false" for fire-and-forget if you prefer lower latency
+# over write confirmation.
+EZ1_BRIDGE_SETMAXPOWER_VERIFY=true
+
 # --- MQTT broker ----------------------------------------------------------
 EZ1_BRIDGE_MQTT_HOST=192.168.2.10
 EZ1_BRIDGE_MQTT_PORT=1883

--- a/src/ez1_bridge/adapters/mqtt_publisher.py
+++ b/src/ez1_bridge/adapters/mqtt_publisher.py
@@ -122,6 +122,17 @@ class MQTTPublisher:
         """MQTT client_id used during CONNECT."""
         return self._identifier
 
+    @property
+    def client(self) -> aiomqtt.Client:
+        """The underlying ``aiomqtt.Client`` (for code paths that need to
+        subscribe and consume messages, e.g. the command handler).
+
+        Raises :class:`RuntimeError` if accessed outside the async context
+        manager. The publisher remains the owner of the client lifecycle;
+        callers must not close it.
+        """
+        return self._ensure_client()
+
     def _build_client(self) -> aiomqtt.Client:
         """Create the underlying ``aiomqtt.Client`` with LWT preset.
 

--- a/src/ez1_bridge/application/command_handler.py
+++ b/src/ez1_bridge/application/command_handler.py
@@ -1,18 +1,449 @@
-"""MQTT command dispatcher — forwards write requests to the EZ1 inverter.
+"""MQTT command dispatcher: forwards write requests to the EZ1 inverter.
 
-Subscribes to ``{base}/{device_id}/set/+``, validates payloads against the
-device's ``minPower``/``maxPower`` bounds, calls the EZ1 API, and publishes
-the outcome to ``{base}/{device_id}/result/+``.
+Subscribes to ``{base}/{device_id}/set/+``, validates each incoming
+payload, calls the matching :class:`EZ1Client` write method, optionally
+re-reads the affected value to verify the inverter accepted it, and
+publishes a structured result on
+``{base}/{device_id}/result/{command}``.
 
-Implementation lands in Phase 5.
+Result-topic payload schema
+---------------------------
 
-Backlog (Phase 5)
------------------
-* **Read-back verification after write.** After a ``setMaxPower`` write,
-  optionally re-poll ``getMaxPower`` after ~2 s and compare. Make this
-  configurable via ``Settings.setmaxpower_verify`` (default ``True``); some
-  users prefer fire-and-forget for latency-sensitive automations. On a
-  mismatch, publish to the result topic with
-  ``{"ok": false, "error": "verify_mismatch", "expected": <int>, "actual": <int>}``
-  so Home Assistant immediately surfaces a discarded write.
+Success::
+
+    {"ok": true, "ts": "2026-04-26T18:00:00+00:00", "value": "600"}
+
+Failure (codes are stable for HA automations to match against)::
+
+    {"ok": false, "ts": "...", "error": "invalid_payload", "detail": "..."}
+    {"ok": false, "ts": "...", "error": "out_of_range", "detail": "..."}
+    {"ok": false, "ts": "...", "error": "transport_error", "detail": "..."}
+    {
+        "ok": false,
+        "ts": "...",
+        "error": "verify_mismatch",
+        "detail": "...",
+        "expected": 600,
+        "actual": 800,
+    }
+
+Concurrency
+-----------
+
+Commands are dispatched sequentially within :func:`command_loop`. The
+EZ1 inverter serialises its own HTTP requests anyway, so two
+back-to-back set commands queue at the broker (QoS 1) and process in
+order. If concurrent dispatch ever becomes a need, hand each handler
+to ``tg.create_task`` instead of awaiting it inline -- the result-publish
+flow does not depend on serialisation.
+
+Cancellation
+------------
+
+The loop's ``async for`` over the MQTT message stream is the only
+blocking point that does not observe ``stop_event`` between events.
+:func:`run_service` therefore awaits ``stop_event`` itself and calls
+``command_task.cancel()`` to break the iterator; :class:`asyncio.CancelledError`
+propagates out cleanly.
 """
+
+from __future__ import annotations
+
+import asyncio
+import json as json_lib
+from datetime import UTC, datetime
+from typing import Final, Literal
+
+import aiomqtt
+import structlog
+from pydantic import BaseModel, ConfigDict
+
+from ez1_bridge import topics
+from ez1_bridge.adapters.ez1_http import EZ1Client
+from ez1_bridge.adapters.mqtt_publisher import MQTTPublisher
+from ez1_bridge.config import Settings
+from ez1_bridge.domain.models import DeviceInfo
+from ez1_bridge.domain.normalizer import parse_max_power_w
+
+_log = structlog.get_logger(__name__)
+
+#: Default delay between a setMaxPower write and the verify read-back. The
+#: EZ1 firmware needs ~1-2 s to reflect the change on getMaxPower.
+_VERIFY_DELAY_SECONDS: Final[float] = 2.0
+
+CommandName = Literal["max_power", "on_off"]
+ErrorCode = Literal[
+    "invalid_payload",
+    "out_of_range",
+    "transport_error",
+    "verify_mismatch",
+]
+
+
+class CommandResult(BaseModel):
+    """Outgoing payload for ``{base}/{device_id}/result/{command}``.
+
+    All fields except ``ok`` and ``ts`` are optional and serialised only
+    when present, so the wire format stays minimal per result kind.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    ok: bool
+    ts: datetime
+    value: str | None = None
+    error: ErrorCode | None = None
+    detail: str | None = None
+    expected: int | None = None
+    actual: int | None = None
+
+
+# --- Payload parsing ---------------------------------------------------
+
+
+def parse_max_power_payload(payload: str) -> int:
+    """Parse a ``setMaxPower`` payload into watts.
+
+    Accepts a clean integer string. Whitespace is tolerated; anything
+    else (units, decimals, hex, empty) raises :class:`ValueError` so
+    the dispatcher can publish ``invalid_payload``.
+    """
+    stripped = payload.strip()
+    if not stripped:
+        msg = "empty payload"
+        raise ValueError(msg)
+    try:
+        return int(stripped)
+    except ValueError as exc:
+        msg = f"expected integer watts, got {payload!r}"
+        raise ValueError(msg) from exc
+
+
+def parse_on_off_payload(payload: str) -> bool:
+    """Parse a ``setOnOff`` payload into a Python ``bool``.
+
+    Accepts ``"on"``/``"off"`` (case-insensitive, the documented
+    convention) and ``"1"``/``"0"`` (the inverter's wire format, kept
+    as a safety valve for HA users who type the raw value).
+    """
+    stripped = payload.strip().lower()
+    if stripped in {"on", "1"}:
+        return True
+    if stripped in {"off", "0"}:
+        return False
+    msg = f"expected 'on'/'off' or '1'/'0', got {payload!r}"
+    raise ValueError(msg)
+
+
+# --- Range validation --------------------------------------------------
+
+
+def validate_max_power_in_range(watts: int, info: DeviceInfo) -> None:
+    """Reject ``watts`` outside ``[info.min_power_w, info.max_power_w]``.
+
+    Bounds come from the live ``getDeviceInfo`` response, not hard-coded
+    constants -- a future inverter with a different range works without
+    code changes.
+    """
+    if watts < info.min_power_w or watts > info.max_power_w:
+        msg = f"value {watts} outside [{info.min_power_w}, {info.max_power_w}]"
+        raise ValueError(msg)
+
+
+# --- Verify read-back --------------------------------------------------
+
+
+async def verify_max_power(
+    ez1: EZ1Client,
+    *,
+    delay_s: float = _VERIFY_DELAY_SECONDS,
+) -> int:
+    """Wait briefly, then return the current ``getMaxPower`` value.
+
+    Caller compares the result against the value it wrote and emits a
+    ``verify_mismatch`` result if they differ. The sleep gives the
+    inverter time to reflect the write on getMaxPower (1-2 s in
+    practice on firmware EZ1 1.12.2t).
+    """
+    await asyncio.sleep(delay_s)
+    return parse_max_power_w(await ez1.get_max_power())
+
+
+# --- Result publishing -------------------------------------------------
+
+
+async def _publish_result(
+    publisher: MQTTPublisher,
+    command_name: CommandName,
+    result: CommandResult,
+) -> None:
+    payload = result.model_dump(mode="json", exclude_none=True)
+    await publisher.publish_result(command_name, payload)
+
+
+# --- Command handlers --------------------------------------------------
+
+
+async def handle_max_power(
+    payload: str,
+    *,
+    ez1: EZ1Client,
+    publisher: MQTTPublisher,
+    device_info: DeviceInfo,
+    verify: bool,
+) -> None:
+    """Process a single ``setMaxPower`` command and publish its result."""
+    started = datetime.now(tz=UTC)
+    try:
+        watts = parse_max_power_payload(payload)
+    except ValueError as exc:
+        await _publish_result(
+            publisher,
+            "max_power",
+            CommandResult(ok=False, ts=started, error="invalid_payload", detail=str(exc)),
+        )
+        return
+
+    try:
+        validate_max_power_in_range(watts, device_info)
+    except ValueError as exc:
+        await _publish_result(
+            publisher,
+            "max_power",
+            CommandResult(ok=False, ts=started, error="out_of_range", detail=str(exc)),
+        )
+        return
+
+    try:
+        await ez1.set_max_power(watts)
+    except Exception as exc:
+        await _publish_result(
+            publisher,
+            "max_power",
+            CommandResult(
+                ok=False,
+                ts=started,
+                error="transport_error",
+                detail=f"{type(exc).__name__}: {exc}",
+            ),
+        )
+        return
+
+    if verify:
+        try:
+            actual = await verify_max_power(ez1)
+        except Exception as exc:
+            await _publish_result(
+                publisher,
+                "max_power",
+                CommandResult(
+                    ok=False,
+                    ts=started,
+                    error="transport_error",
+                    detail=f"verify read-back failed: {type(exc).__name__}: {exc}",
+                ),
+            )
+            return
+        if actual != watts:
+            await _publish_result(
+                publisher,
+                "max_power",
+                CommandResult(
+                    ok=False,
+                    ts=started,
+                    error="verify_mismatch",
+                    detail=f"expected {watts}, actual {actual}",
+                    expected=watts,
+                    actual=actual,
+                ),
+            )
+            return
+
+    await _publish_result(
+        publisher,
+        "max_power",
+        CommandResult(ok=True, ts=datetime.now(tz=UTC), value=str(watts)),
+    )
+
+
+async def handle_on_off(
+    payload: str,
+    *,
+    ez1: EZ1Client,
+    publisher: MQTTPublisher,
+) -> None:
+    """Process a single ``setOnOff`` command and publish its result."""
+    started = datetime.now(tz=UTC)
+    try:
+        on = parse_on_off_payload(payload)
+    except ValueError as exc:
+        await _publish_result(
+            publisher,
+            "on_off",
+            CommandResult(ok=False, ts=started, error="invalid_payload", detail=str(exc)),
+        )
+        return
+
+    try:
+        await ez1.set_on_off(on=on)
+    except Exception as exc:
+        await _publish_result(
+            publisher,
+            "on_off",
+            CommandResult(
+                ok=False,
+                ts=started,
+                error="transport_error",
+                detail=f"{type(exc).__name__}: {exc}",
+            ),
+        )
+        return
+
+    await _publish_result(
+        publisher,
+        "on_off",
+        CommandResult(
+            ok=True,
+            ts=datetime.now(tz=UTC),
+            value="on" if on else "off",
+        ),
+    )
+
+
+# --- Topic dispatch ----------------------------------------------------
+
+
+_KNOWN_COMMANDS: Final[frozenset[CommandName]] = frozenset({"max_power", "on_off"})
+
+
+def parse_command_topic(topic: str, base_topic: str, device_id: str) -> str | None:
+    """Extract the command name from ``{base}/{device_id}/set/{name}``.
+
+    Returns ``None`` if the topic does not match the expected pattern,
+    so the loop can log and ignore stray messages without raising.
+    """
+    expected_prefix = f"{base_topic}/{device_id}/set/"
+    if not topic.startswith(expected_prefix):
+        return None
+    return topic[len(expected_prefix) :]
+
+
+def _decode_payload(raw: bytes | bytearray | str | int | float | None) -> str:
+    """Best-effort decode of the MQTT payload to a UTF-8 string."""
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, bytes | bytearray):
+        return bytes(raw).decode("utf-8", errors="replace")
+    return str(raw)
+
+
+async def _dispatch(
+    *,
+    msg: aiomqtt.Message,
+    ez1: EZ1Client,
+    publisher: MQTTPublisher,
+    device_info: DeviceInfo,
+    settings: Settings,
+) -> None:
+    """Route a single message to the matching handler."""
+    topic_str = str(msg.topic)
+    command_name = parse_command_topic(
+        topic_str,
+        settings.mqtt_base_topic,
+        device_info.device_id,
+    )
+    if command_name is None or command_name not in _KNOWN_COMMANDS:
+        _log.warning("unknown_command_topic", topic=topic_str)
+        return
+
+    payload = _decode_payload(msg.payload)
+    _log.info("command_received", command=command_name, payload=payload)
+
+    if command_name == "max_power":
+        await handle_max_power(
+            payload,
+            ez1=ez1,
+            publisher=publisher,
+            device_info=device_info,
+            verify=settings.setmaxpower_verify,
+        )
+    elif command_name == "on_off":
+        await handle_on_off(payload, ez1=ez1, publisher=publisher)
+
+
+# --- Top-level loop ----------------------------------------------------
+
+
+async def command_loop(
+    *,
+    client: aiomqtt.Client,
+    ez1: EZ1Client,
+    publisher: MQTTPublisher,
+    device_info: DeviceInfo,
+    settings: Settings,
+    stop_event: asyncio.Event,
+) -> None:
+    """Subscribe to ``set/+`` and dispatch commands until cancelled.
+
+    The loop exits via two paths:
+
+    * ``stop_event`` is observed between messages -- the next iteration
+      sees it set and returns. Reasonable when commands keep arriving.
+    * The task is cancelled by :func:`run_service` after ``stop_event``
+      fires while no message is in flight. The ``async for`` raises
+      :class:`asyncio.CancelledError` and propagates cleanly.
+    """
+    subscription = topics.command_wildcard(
+        settings.mqtt_base_topic,
+        device_info.device_id,
+    )
+    await client.subscribe(subscription, qos=1)
+    _log.info("command_loop_subscribed", topic=subscription)
+
+    async for msg in client.messages:
+        if stop_event.is_set():
+            return
+        try:
+            await _dispatch(
+                msg=msg,
+                ez1=ez1,
+                publisher=publisher,
+                device_info=device_info,
+                settings=settings,
+            )
+        except Exception:
+            # A handler-level catastrophe must not kill the whole loop;
+            # the result topic already conveys per-command failures.
+            _log.warning("command_dispatch_failed", exc_info=True)
+            # Best-effort: emit a generic failure on the (best-guess)
+            # result topic so HA does not silently drop the command.
+            await _emit_dispatch_failure(msg, publisher, settings, device_info)
+
+
+async def _emit_dispatch_failure(
+    msg: aiomqtt.Message,
+    publisher: MQTTPublisher,
+    settings: Settings,
+    device_info: DeviceInfo,
+) -> None:
+    """Publish a generic transport_error result on dispatch-loop failure."""
+    command_name = parse_command_topic(
+        str(msg.topic),
+        settings.mqtt_base_topic,
+        device_info.device_id,
+    )
+    if command_name not in _KNOWN_COMMANDS:
+        return
+    fallback = CommandResult(
+        ok=False,
+        ts=datetime.now(tz=UTC),
+        error="transport_error",
+        detail="dispatch loop raised an unexpected exception",
+    )
+    payload = json_lib.loads(fallback.model_dump_json(exclude_none=True))
+    try:
+        await publisher.publish_result(command_name, payload)
+    except Exception:
+        _log.error("failed_to_publish_dispatch_failure", exc_info=True)

--- a/src/ez1_bridge/config.py
+++ b/src/ez1_bridge/config.py
@@ -44,6 +44,12 @@ class Settings(BaseSettings):
     poll_interval: Annotated[int, Field(ge=1, le=3600)] = 20
     request_timeout: Annotated[int, Field(ge=1, le=60)] = 5
 
+    # --- Commands ---------------------------------------------------------
+    setmaxpower_verify: bool = True
+    """Re-read getMaxPower after a setMaxPower write to confirm the device
+    accepted the value. Set to False for fire-and-forget on latency-sensitive
+    automations -- a verify mismatch is then silent."""
+
     # --- MQTT broker ------------------------------------------------------
     mqtt_host: Annotated[str, Field(min_length=1)]
     mqtt_port: Port = 1883

--- a/src/ez1_bridge/main.py
+++ b/src/ez1_bridge/main.py
@@ -36,6 +36,7 @@ import structlog
 from ez1_bridge import __version__
 from ez1_bridge.adapters.ez1_http import EZ1Client
 from ez1_bridge.adapters.mqtt_publisher import MQTTPublisher
+from ez1_bridge.application.command_handler import command_loop
 from ez1_bridge.application.poll_service import availability_heartbeat, poll_loop
 from ez1_bridge.config import Settings
 from ez1_bridge.domain.normalizer import parse_device_info
@@ -225,6 +226,24 @@ async def run_service(
                         ),
                         name="availability_heartbeat",
                     )
+                    # command_loop subscribes and blocks on async-for; it
+                    # cannot poll stop_event while waiting for a message,
+                    # so we cancel it explicitly once stop_event fires.
+                    # See command_handler.py "Cancellation" docstring.
+                    command_task = tg.create_task(
+                        command_loop(
+                            client=publisher.client,
+                            ez1=ez1,
+                            publisher=publisher,
+                            device_info=device_info,
+                            settings=settings,
+                            stop_event=stop_event,
+                        ),
+                        name="command_loop",
+                    )
+
+                    await stop_event.wait()
+                    command_task.cancel()
             finally:
                 with contextlib.suppress(Exception):
                     await publisher.publish_availability(online=False)

--- a/tests/integration/test_command_e2e.py
+++ b/tests/integration/test_command_e2e.py
@@ -1,0 +1,266 @@
+"""End-to-end Phase-5 integration test for the command handler.
+
+Drives a respx-mocked EZ1 plus a real Mosquitto broker through
+:func:`run_service`, publishes set-commands from an external observer,
+and asserts the result topic carries the expected structured payload.
+
+This is the test that catches "wiring against the real broker plus a
+mocked inverter actually round-trips" regressions that a unit test
+cannot, because it exercises the real MQTT subscribe + dispatch path
+inside the running TaskGroup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import aiomqtt
+import pytest
+import respx
+
+from ez1_bridge.config import Settings
+from ez1_bridge.main import run_service
+
+from .conftest import BrokerEndpoint
+
+pytestmark = pytest.mark.integration
+
+_E2E_TIMEOUT_SECONDS = 15.0
+_SUBSCRIPTION_WARMUP_SECONDS = 0.1
+
+
+def _make_settings(
+    *,
+    ez1_host: str,
+    mqtt_host: str,
+    mqtt_port: int,
+    setmaxpower_verify: bool,
+) -> Settings:
+    return Settings(  # type: ignore[call-arg]
+        _env_file=None,
+        ez1_host=ez1_host,
+        ez1_port=8050,
+        mqtt_host=mqtt_host,
+        mqtt_port=mqtt_port,
+        mqtt_base_topic="ez1",
+        mqtt_discovery_prefix="homeassistant",
+        poll_interval=2,
+        request_timeout=2,
+        setmaxpower_verify=setmaxpower_verify,
+    )
+
+
+def _arm_ez1_respx(
+    api_response: Callable[[str], dict[str, Any]],
+    host: str,
+    *,
+    device_id: str,
+) -> dict[str, respx.Route]:
+    """Mount fixture responses for every read endpoint and capture write routes."""
+    base = f"http://{host}:8050"
+    device_info = api_response("get_device_info").copy()
+    device_info["data"] = {**device_info["data"], "deviceId": device_id}
+    device_info["deviceId"] = device_id
+    output_data = api_response("get_output_data").copy()
+    output_data["deviceId"] = device_id
+    max_power = api_response("get_max_power").copy()
+    max_power["deviceId"] = device_id
+    alarm = api_response("get_alarm").copy()
+    alarm["deviceId"] = device_id
+    on_off = api_response("get_on_off").copy()
+    on_off["deviceId"] = device_id
+
+    respx.get(f"{base}/getDeviceInfo").mock(
+        return_value=respx.MockResponse(200, json=device_info),
+    )
+    respx.get(f"{base}/getOutputData").mock(
+        return_value=respx.MockResponse(200, json=output_data),
+    )
+    respx.get(f"{base}/getMaxPower").mock(
+        return_value=respx.MockResponse(200, json=max_power),
+    )
+    respx.get(f"{base}/getAlarm").mock(
+        return_value=respx.MockResponse(200, json=alarm),
+    )
+    respx.get(f"{base}/getOnOff").mock(
+        return_value=respx.MockResponse(200, json=on_off),
+    )
+    set_max = respx.get(f"{base}/setMaxPower").mock(
+        return_value=respx.MockResponse(
+            200,
+            json={"data": {"maxPower": "600"}, "message": "SUCCESS", "deviceId": device_id},
+        ),
+    )
+    set_on_off = respx.get(f"{base}/setOnOff").mock(
+        return_value=respx.MockResponse(
+            200,
+            json={"data": {"status": "1"}, "message": "SUCCESS", "deviceId": device_id},
+        ),
+    )
+    return {"set_max_power": set_max, "set_on_off": set_on_off}
+
+
+async def _wait_for_message_on(
+    client: aiomqtt.Client,
+    expected_topic: str,
+    *,
+    timeout: float = _E2E_TIMEOUT_SECONDS,
+) -> aiomqtt.Message:
+    async with asyncio.timeout(timeout):
+        async for msg in client.messages:
+            if str(msg.topic) == expected_topic:
+                return msg
+    err = f"no message on {expected_topic} within {timeout}s"
+    raise TimeoutError(err)
+
+
+@respx.mock
+async def test_set_max_power_round_trip(
+    mosquitto_broker: BrokerEndpoint,
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    """A setMaxPower command produces an ok=true result with the value."""
+    device_id = f"E{uuid.uuid4().hex[:12].upper()}"
+    fake_ez1_host = f"ez1-{device_id.lower()}.test"
+    routes = _arm_ez1_respx(api_response, fake_ez1_host, device_id=device_id)
+    settings = _make_settings(
+        ez1_host=fake_ez1_host,
+        mqtt_host=mosquitto_broker.host,
+        mqtt_port=mosquitto_broker.port,
+        setmaxpower_verify=False,
+    )
+    stop_event = asyncio.Event()
+
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"cmd-observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(f"ez1/{device_id}/result/+", qos=1)
+        await asyncio.sleep(_SUBSCRIPTION_WARMUP_SECONDS)
+
+        service_task = asyncio.create_task(run_service(settings, stop_event=stop_event))
+        # Give the bridge time to start, resolve device_id, subscribe to set/+.
+        await asyncio.sleep(1.5)
+
+        await observer.publish(
+            f"ez1/{device_id}/set/max_power",
+            payload="600",
+            qos=1,
+        )
+
+        result_topic = f"ez1/{device_id}/result/max_power"
+        msg = await _wait_for_message_on(observer, result_topic, timeout=8.0)
+        result = json.loads(bytes(msg.payload).decode("utf-8"))
+
+        stop_event.set()
+        await asyncio.wait_for(service_task, timeout=5.0)
+
+    assert result["ok"] is True
+    assert result["value"] == "600"
+    assert "error" not in result
+    assert routes["set_max_power"].call_count == 1
+    assert routes["set_max_power"].calls.last.request.url.params["p"] == "600"
+
+
+@respx.mock
+async def test_set_on_off_round_trip(
+    mosquitto_broker: BrokerEndpoint,
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    """A setOnOff command produces an ok=true result and inverts the wire bit correctly."""
+    device_id = f"E{uuid.uuid4().hex[:12].upper()}"
+    fake_ez1_host = f"ez1-{device_id.lower()}.test"
+    routes = _arm_ez1_respx(api_response, fake_ez1_host, device_id=device_id)
+    settings = _make_settings(
+        ez1_host=fake_ez1_host,
+        mqtt_host=mosquitto_broker.host,
+        mqtt_port=mosquitto_broker.port,
+        setmaxpower_verify=False,
+    )
+    stop_event = asyncio.Event()
+
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"cmd-observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(f"ez1/{device_id}/result/+", qos=1)
+        await asyncio.sleep(_SUBSCRIPTION_WARMUP_SECONDS)
+
+        service_task = asyncio.create_task(run_service(settings, stop_event=stop_event))
+        await asyncio.sleep(1.5)
+
+        await observer.publish(f"ez1/{device_id}/set/on_off", payload="off", qos=1)
+
+        msg = await _wait_for_message_on(
+            observer,
+            f"ez1/{device_id}/result/on_off",
+            timeout=8.0,
+        )
+        result = json.loads(bytes(msg.payload).decode("utf-8"))
+
+        stop_event.set()
+        await asyncio.wait_for(service_task, timeout=5.0)
+
+    assert result["ok"] is True
+    assert result["value"] == "off"
+    assert routes["set_on_off"].call_count == 1
+    # Inverted on the wire: "off" -> status=1
+    assert routes["set_on_off"].calls.last.request.url.params["status"] == "1"
+
+
+@respx.mock
+async def test_set_max_power_out_of_range_publishes_structured_error(
+    mosquitto_broker: BrokerEndpoint,
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    """A value above the device's max_power produces ok=false + out_of_range."""
+    device_id = f"E{uuid.uuid4().hex[:12].upper()}"
+    fake_ez1_host = f"ez1-{device_id.lower()}.test"
+    routes = _arm_ez1_respx(api_response, fake_ez1_host, device_id=device_id)
+    settings = _make_settings(
+        ez1_host=fake_ez1_host,
+        mqtt_host=mosquitto_broker.host,
+        mqtt_port=mosquitto_broker.port,
+        setmaxpower_verify=False,
+    )
+    stop_event = asyncio.Event()
+
+    async with aiomqtt.Client(
+        hostname=mosquitto_broker.host,
+        port=mosquitto_broker.port,
+        identifier=f"cmd-observer-{device_id}",
+    ) as observer:
+        await observer.subscribe(f"ez1/{device_id}/result/+", qos=1)
+        await asyncio.sleep(_SUBSCRIPTION_WARMUP_SECONDS)
+
+        service_task = asyncio.create_task(run_service(settings, stop_event=stop_event))
+        await asyncio.sleep(1.5)
+
+        # 1000 is above the documented 800 W max_power for this device.
+        await observer.publish(
+            f"ez1/{device_id}/set/max_power",
+            payload="1000",
+            qos=1,
+        )
+
+        msg = await _wait_for_message_on(
+            observer,
+            f"ez1/{device_id}/result/max_power",
+            timeout=8.0,
+        )
+        result = json.loads(bytes(msg.payload).decode("utf-8"))
+
+        stop_event.set()
+        await asyncio.wait_for(service_task, timeout=5.0)
+
+    assert result["ok"] is False
+    assert result["error"] == "out_of_range"
+    assert "1000" in result["detail"]
+    # Critical guard: the EZ1 set endpoint must NOT have been called.
+    assert routes["set_max_power"].call_count == 0

--- a/tests/unit/test_command_handler.py
+++ b/tests/unit/test_command_handler.py
@@ -1,0 +1,796 @@
+"""Unit tests for :mod:`ez1_bridge.application.command_handler`.
+
+Hand-rolled async iterator helps simulate aiomqtt.Client.messages so the
+``command_loop`` can be driven deterministically without a real broker.
+The real-broker round-trip lives in
+``tests/integration/test_command_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import aiomqtt
+import pytest
+from pydantic import ValidationError
+
+from ez1_bridge.application.command_handler import (
+    _KNOWN_COMMANDS,
+    CommandResult,
+    _decode_payload,
+    _dispatch,
+    _emit_dispatch_failure,
+    command_loop,
+    handle_max_power,
+    handle_on_off,
+    parse_command_topic,
+    parse_max_power_payload,
+    parse_on_off_payload,
+    validate_max_power_in_range,
+    verify_max_power,
+)
+from ez1_bridge.config import Settings
+from ez1_bridge.domain.models import DeviceInfo
+
+
+def _make_settings(**overrides: Any) -> Settings:
+    base: dict[str, Any] = {
+        "ez1_host": "192.168.3.24",
+        "mqtt_host": "192.168.2.10",
+        "mqtt_base_topic": "ez1",
+        "mqtt_discovery_prefix": "homeassistant",
+        "setmaxpower_verify": True,
+    }
+    base.update(overrides)
+    return Settings(_env_file=None, **base)  # type: ignore[call-arg]
+
+
+@pytest.fixture
+def device_info() -> DeviceInfo:
+    return DeviceInfo(
+        device_id="E17010000783",
+        firmware_version="EZ1 1.12.2t",
+        ssid="my-wlan",
+        ip_address="192.168.3.24",
+        min_power_w=30,
+        max_power_w=800,
+    )
+
+
+# --- Payload parsers ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [("600", 600), ("30", 30), ("0", 0), ("  450  ", 450)],
+)
+def test_parse_max_power_payload_accepts_clean_int(payload: str, expected: int) -> None:
+    assert parse_max_power_payload(payload) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "600W", "600.0", "abc", "0x100", "--1"])
+def test_parse_max_power_payload_rejects_garbage(bad: str) -> None:
+    with pytest.raises(ValueError, match=r"empty payload|integer watts"):
+        parse_max_power_payload(bad)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("on", True),
+        ("ON", True),
+        ("On", True),
+        ("1", True),
+        ("off", False),
+        ("OFF", False),
+        ("0", False),
+        ("  on  ", True),
+    ],
+)
+def test_parse_on_off_payload(payload: str, expected: bool) -> None:
+    assert parse_on_off_payload(payload) is expected
+
+
+@pytest.mark.parametrize("bad", ["", "maybe", "true", "yes", "2"])
+def test_parse_on_off_payload_rejects_garbage(bad: str) -> None:
+    with pytest.raises(ValueError, match="expected"):
+        parse_on_off_payload(bad)
+
+
+# --- Range validation -------------------------------------------------
+
+
+def test_validate_max_power_accepts_in_range(device_info: DeviceInfo) -> None:
+    validate_max_power_in_range(30, device_info)
+    validate_max_power_in_range(450, device_info)
+    validate_max_power_in_range(800, device_info)
+
+
+@pytest.mark.parametrize("watts", [-10, 0, 29, 801, 9999])
+def test_validate_max_power_rejects_out_of_range(
+    device_info: DeviceInfo,
+    watts: int,
+) -> None:
+    with pytest.raises(ValueError, match="outside"):
+        validate_max_power_in_range(watts, device_info)
+
+
+# --- parse_command_topic ----------------------------------------------
+
+
+def test_parse_command_topic_extracts_name() -> None:
+    assert parse_command_topic("ez1/E1/set/max_power", "ez1", "E1") == "max_power"
+    assert parse_command_topic("ez1/E1/set/on_off", "ez1", "E1") == "on_off"
+
+
+def test_parse_command_topic_returns_none_for_state_topic() -> None:
+    assert parse_command_topic("ez1/E1/state", "ez1", "E1") is None
+
+
+def test_parse_command_topic_returns_none_for_other_device() -> None:
+    assert parse_command_topic("ez1/OTHER/set/max_power", "ez1", "E1") is None
+
+
+def test_parse_command_topic_returns_none_for_other_base() -> None:
+    assert parse_command_topic("solar/E1/set/max_power", "ez1", "E1") is None
+
+
+# --- _decode_payload --------------------------------------------------
+
+
+def test_decode_payload_bytes() -> None:
+    assert _decode_payload(b"hello") == "hello"
+
+
+def test_decode_payload_str() -> None:
+    assert _decode_payload("hello") == "hello"
+
+
+def test_decode_payload_none() -> None:
+    assert _decode_payload(None) == ""
+
+
+def test_decode_payload_int_falls_back_to_str() -> None:
+    assert _decode_payload(42) == "42"
+
+
+def test_decode_payload_invalid_utf8_replaced() -> None:
+    assert _decode_payload(b"\xff\xfe") == "��"
+
+
+# --- handle_max_power -------------------------------------------------
+
+
+@pytest.fixture
+def mock_publisher() -> MagicMock:
+    pub = MagicMock()
+    pub.publish_result = AsyncMock()
+    return pub
+
+
+@pytest.fixture
+def mock_ez1() -> MagicMock:
+    ez1 = MagicMock()
+    ez1.set_max_power = AsyncMock(return_value={"data": {"maxPower": "600"}, "message": "SUCCESS"})
+    ez1.set_on_off = AsyncMock(return_value={"data": {"status": "0"}, "message": "SUCCESS"})
+    ez1.get_max_power = AsyncMock(
+        return_value={"data": {"maxPower": "600"}, "message": "SUCCESS", "deviceId": "E1"},
+    )
+    return ez1
+
+
+def _last_result(mock_publisher: MagicMock) -> dict[str, Any]:
+    """Return the dict payload of the most recent publish_result call."""
+    args = mock_publisher.publish_result.await_args
+    payload = args.args[1] if len(args.args) > 1 else args.kwargs["payload"]
+    return cast("dict[str, Any]", payload)
+
+
+async def test_handle_max_power_success_publishes_ok_true(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    await handle_max_power(
+        "600",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=False,
+    )
+
+    mock_ez1.set_max_power.assert_awaited_once_with(600)
+    result = _last_result(mock_publisher)
+    assert result["ok"] is True
+    assert result["value"] == "600"
+    assert "error" not in result
+
+
+async def test_handle_max_power_invalid_payload(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    await handle_max_power(
+        "abc",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=False,
+    )
+
+    mock_ez1.set_max_power.assert_not_awaited()
+    result = _last_result(mock_publisher)
+    assert result["ok"] is False
+    assert result["error"] == "invalid_payload"
+    assert "abc" in result["detail"]
+
+
+async def test_handle_max_power_out_of_range(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    await handle_max_power(
+        "1000",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=False,
+    )
+
+    mock_ez1.set_max_power.assert_not_awaited()
+    result = _last_result(mock_publisher)
+    assert result["ok"] is False
+    assert result["error"] == "out_of_range"
+    assert "1000" in result["detail"]
+    assert "800" in result["detail"]
+
+
+async def test_handle_max_power_transport_error(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    mock_ez1.set_max_power.side_effect = RuntimeError("connection refused")
+    await handle_max_power(
+        "600",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=False,
+    )
+
+    result = _last_result(mock_publisher)
+    assert result["ok"] is False
+    assert result["error"] == "transport_error"
+    assert "RuntimeError" in result["detail"]
+
+
+async def test_handle_max_power_verify_mismatch(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the read-back returns a different value, publish verify_mismatch."""
+    monkeypatch.setattr(
+        "ez1_bridge.application.command_handler._VERIFY_DELAY_SECONDS",
+        0.0,
+    )
+    mock_ez1.get_max_power.return_value = {
+        "data": {"maxPower": "800"},
+        "message": "SUCCESS",
+        "deviceId": "E1",
+    }
+
+    await handle_max_power(
+        "600",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=True,
+    )
+
+    result = _last_result(mock_publisher)
+    assert result["ok"] is False
+    assert result["error"] == "verify_mismatch"
+    assert result["expected"] == 600
+    assert result["actual"] == 800
+
+
+async def test_handle_max_power_verify_match_publishes_ok(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ez1_bridge.application.command_handler._VERIFY_DELAY_SECONDS",
+        0.0,
+    )
+    mock_ez1.get_max_power.return_value = {
+        "data": {"maxPower": "600"},
+        "message": "SUCCESS",
+        "deviceId": "E1",
+    }
+
+    await handle_max_power(
+        "600",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=True,
+    )
+
+    result = _last_result(mock_publisher)
+    assert result["ok"] is True
+
+
+async def test_handle_max_power_verify_off_skips_readback(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    await handle_max_power(
+        "600",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=False,
+    )
+
+    mock_ez1.get_max_power.assert_not_awaited()
+    assert _last_result(mock_publisher)["ok"] is True
+
+
+async def test_handle_max_power_verify_readback_fails(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If get_max_power itself raises, publish transport_error, not verify_mismatch."""
+    monkeypatch.setattr(
+        "ez1_bridge.application.command_handler._VERIFY_DELAY_SECONDS",
+        0.0,
+    )
+    mock_ez1.get_max_power.side_effect = RuntimeError("read-back unreachable")
+
+    await handle_max_power(
+        "600",
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        verify=True,
+    )
+
+    result = _last_result(mock_publisher)
+    assert result["ok"] is False
+    assert result["error"] == "transport_error"
+    assert "verify read-back" in result["detail"]
+
+
+# --- handle_on_off ----------------------------------------------------
+
+
+async def test_handle_on_off_on(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+) -> None:
+    await handle_on_off("on", ez1=mock_ez1, publisher=mock_publisher)
+    mock_ez1.set_on_off.assert_awaited_once_with(on=True)
+    result = _last_result(mock_publisher)
+    assert result["ok"] is True
+    assert result["value"] == "on"
+
+
+async def test_handle_on_off_off(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+) -> None:
+    await handle_on_off("off", ez1=mock_ez1, publisher=mock_publisher)
+    mock_ez1.set_on_off.assert_awaited_once_with(on=False)
+    result = _last_result(mock_publisher)
+    assert result["ok"] is True
+    assert result["value"] == "off"
+
+
+async def test_handle_on_off_zero_one_aliases(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+) -> None:
+    await handle_on_off("1", ez1=mock_ez1, publisher=mock_publisher)
+    mock_ez1.set_on_off.assert_awaited_with(on=True)
+    await handle_on_off("0", ez1=mock_ez1, publisher=mock_publisher)
+    mock_ez1.set_on_off.assert_awaited_with(on=False)
+
+
+async def test_handle_on_off_invalid_payload(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+) -> None:
+    await handle_on_off("maybe", ez1=mock_ez1, publisher=mock_publisher)
+    mock_ez1.set_on_off.assert_not_awaited()
+    result = _last_result(mock_publisher)
+    assert result["ok"] is False
+    assert result["error"] == "invalid_payload"
+
+
+async def test_handle_on_off_transport_error(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+) -> None:
+    mock_ez1.set_on_off.side_effect = RuntimeError("boom")
+    await handle_on_off("on", ez1=mock_ez1, publisher=mock_publisher)
+    result = _last_result(mock_publisher)
+    assert result["ok"] is False
+    assert result["error"] == "transport_error"
+
+
+# --- verify_max_power -------------------------------------------------
+
+
+async def test_verify_max_power_reads_after_delay(
+    mock_ez1: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+    mock_ez1.get_max_power.return_value = {
+        "data": {"maxPower": "750"},
+        "message": "SUCCESS",
+        "deviceId": "E1",
+    }
+
+    result = await verify_max_power(mock_ez1, delay_s=2.0)
+
+    assert result == 750
+    assert sleep_calls == [2.0]
+
+
+# --- _dispatch --------------------------------------------------------
+
+
+async def _msg(topic: str, payload: bytes) -> aiomqtt.Message:
+    """Build a minimal aiomqtt.Message-like object for dispatch tests."""
+    msg = MagicMock(spec=aiomqtt.Message)
+    msg.topic = MagicMock()
+    msg.topic.__str__ = lambda _self: topic
+    msg.payload = payload
+    return cast("aiomqtt.Message", msg)
+
+
+async def test_dispatch_routes_max_power(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    settings = _make_settings(setmaxpower_verify=False)
+    msg = await _msg("ez1/E17010000783/set/max_power", b"600")
+
+    await _dispatch(
+        msg=msg,
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        settings=settings,
+    )
+
+    mock_ez1.set_max_power.assert_awaited_once_with(600)
+
+
+async def test_dispatch_routes_on_off(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    settings = _make_settings()
+    msg = await _msg("ez1/E17010000783/set/on_off", b"on")
+
+    await _dispatch(
+        msg=msg,
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        settings=settings,
+    )
+
+    mock_ez1.set_on_off.assert_awaited_once_with(on=True)
+
+
+async def test_dispatch_ignores_unknown_command(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    settings = _make_settings()
+    msg = await _msg("ez1/E17010000783/set/foobar", b"value")
+
+    await _dispatch(
+        msg=msg,
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        settings=settings,
+    )
+
+    mock_ez1.set_max_power.assert_not_awaited()
+    mock_ez1.set_on_off.assert_not_awaited()
+    mock_publisher.publish_result.assert_not_awaited()
+
+
+async def test_dispatch_ignores_unrelated_topic(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    settings = _make_settings()
+    msg = await _msg("ez1/E17010000783/state", b"...")
+
+    await _dispatch(
+        msg=msg,
+        ez1=mock_ez1,
+        publisher=mock_publisher,
+        device_info=device_info,
+        settings=settings,
+    )
+
+    mock_publisher.publish_result.assert_not_awaited()
+
+
+# --- command_loop -----------------------------------------------------
+
+
+class _FakeMessageStream:
+    """Async-iterable that yields a fixed set of messages then blocks forever.
+
+    Mimics aiomqtt.Client.messages closely enough for command_loop's
+    contract: subscribe + async for with cancellation support.
+    """
+
+    def __init__(self, messages: list[aiomqtt.Message]) -> None:
+        self._queue: asyncio.Queue[aiomqtt.Message] = asyncio.Queue()
+        for m in messages:
+            self._queue.put_nowait(m)
+
+    def __aiter__(self) -> AsyncIterator[aiomqtt.Message]:
+        return self
+
+    async def __anext__(self) -> aiomqtt.Message:
+        return await self._queue.get()
+
+
+def _fake_client(messages: list[aiomqtt.Message]) -> MagicMock:
+    client = MagicMock(spec=aiomqtt.Client)
+    client.subscribe = AsyncMock()
+    client.messages = _FakeMessageStream(messages)
+    return client
+
+
+async def test_command_loop_subscribes_and_dispatches(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    settings = _make_settings(setmaxpower_verify=False)
+    msg1 = await _msg("ez1/E17010000783/set/max_power", b"600")
+    msg2 = await _msg("ez1/E17010000783/set/on_off", b"off")
+
+    stop_event = asyncio.Event()
+    client = _fake_client([msg1, msg2])
+
+    async def stop_after_two() -> None:
+        # Wait for both publish_result calls, then signal stop.
+        while mock_publisher.publish_result.await_count < 2:
+            await asyncio.sleep(0.01)
+        stop_event.set()
+
+    _trigger = asyncio.create_task(stop_after_two())
+    loop_task = asyncio.create_task(
+        command_loop(
+            client=client,
+            ez1=mock_ez1,
+            publisher=mock_publisher,
+            device_info=device_info,
+            settings=settings,
+            stop_event=stop_event,
+        ),
+    )
+    # Loop will hang on the empty queue after two messages -- cancel it
+    # once both dispatched, mirroring run_service's stop pattern.
+    await _trigger
+    loop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await loop_task
+
+    client.subscribe.assert_awaited_once_with("ez1/E17010000783/set/+", qos=1)
+    mock_ez1.set_max_power.assert_awaited_once_with(600)
+    mock_ez1.set_on_off.assert_awaited_once_with(on=False)
+
+
+async def test_command_loop_exits_cleanly_on_cancel(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    """Cancellation of the task while waiting on async-for must not hang.
+
+    This is the lackmustest the user asked for: TaskGroup-style external
+    cancel of command_loop must complete within 1 s.
+    """
+    settings = _make_settings()
+    stop_event = asyncio.Event()
+    client = _fake_client([])  # empty queue -> async-for hangs forever
+
+    loop_task = asyncio.create_task(
+        command_loop(
+            client=client,
+            ez1=mock_ez1,
+            publisher=mock_publisher,
+            device_info=device_info,
+            settings=settings,
+            stop_event=stop_event,
+        ),
+    )
+    await asyncio.sleep(0.05)  # let it subscribe + start blocking on async-for
+    loop_task.cancel()
+
+    async with asyncio.timeout(1.0):
+        with pytest.raises(asyncio.CancelledError):
+            await loop_task
+
+
+async def test_command_loop_stop_event_observed_between_messages(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    """If stop_event fires while a message is being processed, the loop
+    returns on the *next* iteration without dispatching that message.
+    """
+    settings = _make_settings(setmaxpower_verify=False)
+    msg1 = await _msg("ez1/E17010000783/set/max_power", b"600")
+    msg2 = await _msg("ez1/E17010000783/set/on_off", b"on")
+
+    stop_event = asyncio.Event()
+    client = _fake_client([msg1, msg2])
+
+    async def fake_set_max_power(_w: int) -> dict[str, Any]:
+        stop_event.set()
+        return {"data": {"maxPower": "600"}, "message": "SUCCESS"}
+
+    mock_ez1.set_max_power = AsyncMock(side_effect=fake_set_max_power)
+
+    await asyncio.wait_for(
+        command_loop(
+            client=client,
+            ez1=mock_ez1,
+            publisher=mock_publisher,
+            device_info=device_info,
+            settings=settings,
+            stop_event=stop_event,
+        ),
+        timeout=1.0,
+    )
+
+    mock_ez1.set_max_power.assert_awaited_once()
+    mock_ez1.set_on_off.assert_not_awaited()
+
+
+async def test_command_loop_swallows_handler_exception(
+    mock_ez1: MagicMock,
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    """A catastrophic raise inside _dispatch must not kill the loop.
+
+    The fallback emits a transport_error result on the (best-guess)
+    result topic so HA does not silently drop the command.
+    """
+    settings = _make_settings(setmaxpower_verify=False)
+    msg1 = await _msg("ez1/E17010000783/set/max_power", b"600")
+    msg2 = await _msg("ez1/E17010000783/set/on_off", b"on")
+
+    stop_event = asyncio.Event()
+    client = _fake_client([msg1, msg2])
+
+    # First publish_result raises; second must still be reached.
+    raised_once = {"flag": False}
+
+    async def maybe_raise(*args: Any, **kwargs: Any) -> None:
+        if not raised_once["flag"]:
+            raised_once["flag"] = True
+            msg = "broker stalled"
+            raise RuntimeError(msg)
+
+    mock_publisher.publish_result.side_effect = maybe_raise
+
+    async def stop_when_done() -> None:
+        while mock_publisher.publish_result.await_count < 3:
+            await asyncio.sleep(0.01)
+        stop_event.set()
+
+    _trigger = asyncio.create_task(stop_when_done())
+    loop_task = asyncio.create_task(
+        command_loop(
+            client=client,
+            ez1=mock_ez1,
+            publisher=mock_publisher,
+            device_info=device_info,
+            settings=settings,
+            stop_event=stop_event,
+        ),
+    )
+    await _trigger
+    loop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await loop_task
+
+    # Three calls expected: original failure, dispatch-failure fallback,
+    # then the second message's success.
+    assert mock_publisher.publish_result.await_count >= 2
+
+
+# --- _emit_dispatch_failure -------------------------------------------
+
+
+async def test_emit_dispatch_failure_skips_unknown_command(
+    mock_publisher: MagicMock,
+    device_info: DeviceInfo,
+) -> None:
+    settings = _make_settings()
+    msg = await _msg("ez1/E17010000783/set/unknown", b"x")
+
+    await _emit_dispatch_failure(msg, mock_publisher, settings, device_info)
+
+    mock_publisher.publish_result.assert_not_awaited()
+
+
+# --- CommandResult ----------------------------------------------------
+
+
+def test_command_result_serialises_compact_on_success() -> None:
+    result = CommandResult(
+        ok=True,
+        ts=datetime(2026, 4, 26, 18, 0, tzinfo=UTC),
+        value="600",
+    )
+    dumped = json.loads(result.model_dump_json(exclude_none=True))
+    assert set(dumped.keys()) == {"ok", "ts", "value"}
+
+
+def test_command_result_serialises_with_detail_on_error() -> None:
+    result = CommandResult(
+        ok=False,
+        ts=datetime(2026, 4, 26, 18, 0, tzinfo=UTC),
+        error="out_of_range",
+        detail="value 900 outside [30, 800]",
+    )
+    dumped = json.loads(result.model_dump_json(exclude_none=True))
+    assert dumped["ok"] is False
+    assert dumped["error"] == "out_of_range"
+    assert "value" not in dumped
+
+
+def test_command_result_is_frozen() -> None:
+    result = CommandResult(ok=True, ts=datetime(2026, 4, 26, tzinfo=UTC), value="x")
+    with pytest.raises(ValidationError):
+        result.value = "y"
+
+
+# --- helper-only static checks ----------------------------------------
+
+
+def test_known_commands_set_unchanged() -> None:
+    """Regression guard against silently growing the dispatch table."""
+    assert frozenset({"max_power", "on_off"}) == _KNOWN_COMMANDS

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -53,6 +53,17 @@ def test_defaults_with_only_required_fields_set(isolated_env: pytest.MonkeyPatch
     assert settings.metrics_port == 9100
     assert settings.log_level == "INFO"
     assert settings.log_format == "auto"
+    assert settings.setmaxpower_verify is True
+
+
+def test_setmaxpower_verify_can_be_disabled(isolated_env: pytest.MonkeyPatch) -> None:
+    settings = _make(
+        isolated_env,
+        ez1_host="192.168.3.24",
+        mqtt_host="192.168.2.10",
+        setmaxpower_verify="false",
+    )
+    assert settings.setmaxpower_verify is False
 
 
 def test_required_fields_must_be_set(isolated_env: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_mqtt_publisher.py
+++ b/tests/unit/test_mqtt_publisher.py
@@ -165,6 +165,21 @@ async def test_publish_outside_context_raises() -> None:
         await pub.publish_availability(online=True)
 
 
+async def test_client_property_outside_context_raises() -> None:
+    pub = MQTTPublisher("broker.local", device_id="E1")
+    with pytest.raises(RuntimeError, match="async context manager"):
+        _ = pub.client
+
+
+async def test_client_property_returns_underlying_aiomqtt_client() -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with patch.object(pub, "_build_client", return_value=mock_client):
+        async with pub:
+            assert pub.client is mock_client
+
+
 # --- publish_availability ----------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes the loop on MQTT writes: subscribe to \`{base}/{device_id}/set/+\`, validate, dispatch to the EZ1, optionally read-back, publish a structured result on \`{base}/{device_id}/result/{command}\`. The \`command_loop\` is the third sibling task in the run-service TaskGroup, with an explicit cancel pattern for the iterator-blocking case the user warned about.

### What's in this PR (four atomic commits)

- **\`feat:\`** — Settings gains \`setmaxpower_verify: bool = True\` (read-back verify after a write; \`false\` = fire-and-forget). MQTTPublisher exposes a public \`client\` property so the command handler can subscribe on the same connection the publisher uses for outbound traffic. Three new unit tests.
- **\`feat(application):\`** — \`command_handler.py\` with three distinct validation layers (topic / payload / range), a frozen \`CommandResult\` Pydantic model, a separate \`verify_max_power\` helper (test-injectable delay), and a \`command_loop\` that subscribes + dispatches sequentially with a documented cancellation contract. Result-payload schema fixed before code. **66 unit tests** including the \`test_command_loop_exits_cleanly_on_cancel\` lackmustest.
- **\`feat:\`** — \`run_service\` now spawns \`command_loop\` as the third task, then \`await stop_event.wait()\` in the body, then \`command_task.cancel()\` to break the inner \`async for\`. \`poll_loop\` and \`availability_heartbeat\` continue to observe \`stop_event\` between iterations and exit naturally. The Phase-4 integration tests still pass with the new wiring -- a quiet confirmation that adding a \`CancelledError\`-emitting sibling does not destabilise the orchestrator.
- **\`test(integration):\`** — three e2e round-trips against a real Mosquitto + respx-mocked EZ1: \`set/max_power\` happy path, \`set/on_off\` with on-the-wire-bit-inversion check, and \`set/max_power\` out-of-range with the critical guard that the EZ1 set endpoint is *not* called.

### Result-topic payload schema (machine-readable)

\`\`\`json
{"ok": true,  "ts": "2026-04-26T18:00:00+00:00", "value": "600"}
{"ok": false, "ts": "...", "error": "invalid_payload",  "detail": "..."}
{"ok": false, "ts": "...", "error": "out_of_range",    "detail": "..."}
{"ok": false, "ts": "...", "error": "transport_error", "detail": "..."}
{"ok": false, "ts": "...", "error": "verify_mismatch", "detail": "...",
              "expected": 600, "actual": 800}
\`\`\`

### Cancellation pattern for \`command_loop\`

The \`async for msg in client.messages\` blocks indefinitely. \`stop_event.is_set()\` checks between messages, but no message means no check -- so \`run_service\` itself awaits \`stop_event\` and calls \`command_task.cancel()\`. The \`async for\` raises \`CancelledError\`, the task ends, the TaskGroup completes cleanly. Per the user's discipline reminder: **no \`asyncio.shield()\`, no special-case handling**.

### Quality gates

| Gate | Local | CI |
|---|---|---|
| \`ruff check\` / \`format\` | ✅ | ✅ |
| \`mypy --strict\` (37 files) | ✅ | ✅ |
| \`pytest\` | ✅ 300 tests, 18.8 s | ✅ on 3.12 + 3.13 with real broker |
| Coverage overall | ✅ 98.3 % | ✅ |
| Coverage \`domain/\` | ✅ 100 % | ✅ |

## Test plan

- [x] All gates green locally and in CI on first push.
- [x] \`command_loop\` cancels cleanly within 1 s on the empty-queue lackmustest.
- [x] Phase-4 integration tests (state + discovery + offline) still green with command_loop in the TaskGroup.
- [x] Phase-5 e2e tests verify happy path, inverted on/off bit, and the *no-set-on-out-of-range* invariant.
- [x] verify_mismatch path covered in unit tests against a mocked EZ1.
- [ ] Reviewer confirms commit history has no AI attribution.