### PR TITLE
Phase 7 — Docker, docker-compose, and CI build smoke

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,10 +36,13 @@ tests/
 .github/
 .pre-commit-config.yaml
 .editorconfig
-*.md
 CHANGELOG.md
-LICENSE
-README.md
 CLAUDE.md
 .env
 .env.*
+
+# README.md and LICENSE are intentionally NOT excluded:
+# pyproject.toml references them via readme= and license-files=, so
+# hatchling needs them in the builder stage to produce the project wheel.
+# They do not reach the runtime image because the runtime stage only
+# copies /app/.venv and /app/src from the builder.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,41 @@ jobs:
         # no I/O, so anything less than full line + branch coverage is a
         # missed test, not an environmental quirk.
         run: uv run coverage report --include="src/ez1_bridge/domain/*" --fail-under=100
+
+  docker-build:
+    name: Docker build smoke (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ez1-mqtt-bridge:ci
+          # Single-arch (amd64) for CI feedback speed; Phase-10's release
+          # workflow handles multi-arch via QEMU on the version tags.
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke test --version
+        # Verifies the image actually starts: distroless / slim images
+        # often crash here when a Python module is missing from the venv
+        # copy or a path env var is wrong.
+        run: |
+          OUT="$(docker run --rm ez1-mqtt-bridge:ci --version)"
+          echo "image reports: $OUT"
+          echo "$OUT" | grep -E '^ez1-bridge [0-9]+\.[0-9]+\.[0-9]+'
+      - name: Smoke test probe --help (read-only path reachable)
+        run: docker run --rm ez1-mqtt-bridge:ci probe --help
+      - name: Verify image size against NFR-2 (<= 80 MB compressed)
+        run: |
+          BYTES=$(docker save ez1-mqtt-bridge:ci | gzip -1 | wc -c)
+          MB=$((BYTES / 1024 / 1024))
+          echo "compressed image size: ${MB} MB"
+          if [ "$MB" -gt 80 ]; then
+            echo "::error::compressed image size ${MB} MB exceeds NFR-2 ceiling of 80 MB"
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,107 @@
+# syntax=docker/dockerfile:1.7
+# ---------------------------------------------------------------------------
+# Multi-stage build for ez1-mqtt-bridge.
+#
+# Stage 1 (builder)  — python:3.12-slim + uv: resolves the locked dependency
+#                      tree, populates /app/.venv with pre-compiled bytecode,
+#                      and copies the source.
+#
+# Stage 2 (runtime)  — python:3.12-slim with a non-root user. uv, the wheel
+#                      cache, and build artefacts stay in the builder stage
+#                      so they never reach the runtime layer.
+#
+# Why python:3.12-slim and not gcr.io/distroless/python3-debian12:
+#   distroless/python3-debian12 ships Debian 12's system Python (3.11), and
+#   this codebase requires >= 3.12 (asyncio.TaskGroup features land here, and
+#   pyproject pins requires-python = ">=3.12"). Slim keeps the attack surface
+#   small (~50 MB compressed base) without an interpreter mismatch. A move to
+#   a distroless base with a bundled 3.12 runtime is a Phase-10 hardening
+#   item, not a Phase-7 blocker.
+#
+# Image-size target (project NFR-2): <= 80 MB compressed.
+# ---------------------------------------------------------------------------
+
+ARG PYTHON_IMAGE=python:3.12-slim
+
+# --- Builder stage --------------------------------------------------------
+FROM ${PYTHON_IMAGE} AS builder
+
+# Pin uv to a known-good minor; uv reads uv.lock from the repo so the lock
+# format compatibility window matters. Tag is intentionally hard-coded
+# rather than threaded through an ARG: BuildKit's --from= reference does
+# not substitute global ARGs, and a pinned tag is the right level of
+# friction for a security-sensitive build dependency.
+COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# uv sync settings:
+#   UV_LINK_MODE=copy        — avoid hardlink complaints on cross-FS layers
+#   UV_COMPILE_BYTECODE=1    — pre-compile .pyc so distroless-style runtimes
+#                              have nothing to do at first import
+#   UV_PYTHON_DOWNLOADS=never — don't fetch a managed interpreter; use the
+#                              one already in the slim image
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+# Two-step install for layer-cache friendliness:
+# (1) deps only (no project) — invalidated only when uv.lock or pyproject.toml
+#     change, which is much less frequent than source edits.
+# (2) source + project install — invalidated on every source change.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+# README.md and LICENSE are referenced by pyproject.toml's project metadata
+# (readme = "README.md", license-files = ["LICENSE"]); hatchling validates
+# both before producing the project wheel during the second sync.
+COPY README.md LICENSE ./
+COPY src/ ./src/
+RUN uv sync --frozen --no-dev
+
+# --- Runtime stage --------------------------------------------------------
+FROM ${PYTHON_IMAGE} AS runtime
+
+# Non-root user (UID/GID 65532 mirrors the distroless-nonroot convention so
+# bind-mounted volumes are interchangeable if we move to a distroless base
+# in Phase 10).
+RUN groupadd --gid 65532 nonroot && \
+    useradd --uid 65532 --gid 65532 --no-create-home --shell /usr/sbin/nologin nonroot
+
+WORKDIR /app
+
+COPY --from=builder --chown=nonroot:nonroot /app/.venv /app/.venv
+COPY --from=builder --chown=nonroot:nonroot /app/src /app/src
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONPATH="/app/src" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# OCI image labels per the project spec (NFR-9 / Phase-7 deliverable).
+LABEL org.opencontainers.image.title="ez1-mqtt-bridge" \
+      org.opencontainers.image.description="MQTT bridge for the APsystems EZ1-M micro inverter" \
+      org.opencontainers.image.source="https://github.com/baronblk/ez1-mqtt-bridge" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.authors="René Süß <baronblk@gmail.com>"
+
+USER nonroot
+
+# Healthcheck: poll the bridge's own /metrics endpoint. A 200 response
+# implies (a) the aiohttp server is up, (b) the TaskGroup orchestrator
+# has reached run_service's main body, and (c) the metric pipeline is
+# wired and rendering -- a single round-trip covers liveness + readiness
+# + functional correctness. The check uses python's stdlib urllib because
+# slim has no curl by default and pulling one would bloat the image.
+#
+# Importantly, this must NOT fail when the EZ1 inverter is offline at
+# night: the bridge stays healthy (bridge_up=1, /metrics responds) even
+# while availability=offline -- that is the intended split.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD ["python", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9100/metrics', timeout=4).status == 200 else 1)"]
+
+EXPOSE 9100
+
+ENTRYPOINT ["python", "-m", "ez1_bridge"]
+CMD ["run"]

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ HTTP API to MQTT, with native Home Assistant auto-discovery and Prometheus metri
 - Exposes Prometheus metrics on `:9100/metrics`.
 - Survives nightly inverter offline windows, MQTT disconnects, and bridge restarts
   via LWT and exponential backoff.
-- Multi-arch Docker image (`linux/amd64`, `linux/arm64`), distroless runtime,
-  non-root user.
+- Multi-arch Docker image (`linux/amd64`, `linux/arm64`), `python:3.12-slim`
+  runtime as a non-root user. Image size approx. 50 MB compressed.
 
 ## Tech stack
 
@@ -38,6 +38,36 @@ Python 3.12+ · `httpx` · `aiomqtt` · `pydantic` v2 · `structlog` ·
   empirical edge cases.
 - `docs/architecture.md`, `docs/mqtt-topics.md`, `docs/home-assistant.md` —
   populated in Phase 9.
+
+## Container deployment
+
+```bash
+# Copy and edit the env template
+cp .env.example .env
+$EDITOR .env
+
+# Bring up the bridge (uses ghcr.io/baronblk/ez1-mqtt-bridge once Phase 10 publishes)
+docker compose up -d
+
+# Tail logs
+docker compose logs -f bridge
+
+# Shut down cleanly (LWT triggers + explicit availability=offline publish)
+docker compose down
+```
+
+The `/metrics` endpoint binds to `0.0.0.0:9100` inside the container and is
+forwarded to `127.0.0.1:9100` on the host -- intended for a Prometheus scraper
+on the same host or co-located in the `ez1-bridge-net` Docker network.
+Healthcheck pulls `/metrics` once every 30 s and stays green even when the
+inverter is night-offline.
+
+To build the image locally instead of pulling:
+
+```bash
+docker build -t ez1-mqtt-bridge:local .
+docker run --rm ez1-mqtt-bridge:local --version
+```
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+# Docker Compose deployment for ez1-mqtt-bridge.
+#
+# Mirrors the Dockhand convention used elsewhere in the homelab:
+#   * top-level `name:` so the project identifier does not depend on the
+#     directory name
+#   * map-syntax for `environment:` so each variable is auditable on
+#     its own line
+#   * port-bind on 127.0.0.1 because /metrics is for Prometheus on the
+#     same host (or co-located in a Docker network), never for public
+#     exposure
+#   * json-file logging with rotation so a long-running bridge does not
+#     fill the host disk
+#
+# Copy .env.example to .env and edit before `docker compose up`.
+
+name: ez1-mqtt-bridge
+
+services:
+  bridge:
+    image: ghcr.io/baronblk/ez1-mqtt-bridge:${EZ1_BRIDGE_VERSION:-latest}
+    container_name: ez1-bridge
+    restart: unless-stopped
+    environment:
+      EZ1_BRIDGE_EZ1_HOST: ${EZ1_BRIDGE_EZ1_HOST}
+      EZ1_BRIDGE_EZ1_PORT: ${EZ1_BRIDGE_EZ1_PORT:-8050}
+      EZ1_BRIDGE_POLL_INTERVAL: ${EZ1_BRIDGE_POLL_INTERVAL:-20}
+      EZ1_BRIDGE_REQUEST_TIMEOUT: ${EZ1_BRIDGE_REQUEST_TIMEOUT:-5}
+      EZ1_BRIDGE_SETMAXPOWER_VERIFY: ${EZ1_BRIDGE_SETMAXPOWER_VERIFY:-true}
+      EZ1_BRIDGE_MQTT_HOST: ${EZ1_BRIDGE_MQTT_HOST}
+      EZ1_BRIDGE_MQTT_PORT: ${EZ1_BRIDGE_MQTT_PORT:-1883}
+      EZ1_BRIDGE_MQTT_USER: ${EZ1_BRIDGE_MQTT_USER:-}
+      EZ1_BRIDGE_MQTT_PASSWORD: ${EZ1_BRIDGE_MQTT_PASSWORD:-}
+      EZ1_BRIDGE_MQTT_BASE_TOPIC: ${EZ1_BRIDGE_MQTT_BASE_TOPIC:-ez1}
+      EZ1_BRIDGE_MQTT_DISCOVERY_PREFIX: ${EZ1_BRIDGE_MQTT_DISCOVERY_PREFIX:-homeassistant}
+      EZ1_BRIDGE_METRICS_BIND: ${EZ1_BRIDGE_METRICS_BIND:-0.0.0.0}
+      EZ1_BRIDGE_METRICS_PORT: ${EZ1_BRIDGE_METRICS_PORT:-9100}
+      EZ1_BRIDGE_LOG_LEVEL: ${EZ1_BRIDGE_LOG_LEVEL:-INFO}
+      EZ1_BRIDGE_LOG_FORMAT: ${EZ1_BRIDGE_LOG_FORMAT:-auto}
+    ports:
+      # Bind to the loopback interface only -- /metrics is intended for
+      # a Prometheus scraper running on the same host (or co-located in
+      # the same Docker network using the bridge-net alias below) and
+      # not for direct exposure on the LAN.
+      - "127.0.0.1:9100:9100"
+    networks:
+      - bridge-net
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  bridge-net:
+    name: ez1-bridge-net
+    driver: bridge


### PR DESCRIPTION
## Summary

Packages the bridge into a runnable container: multi-stage \`Dockerfile\` with a non-root \`python:3.12-slim\` runtime, Dockhand-style \`docker-compose.yml\`, a \`/metrics\`-based \`HEALTHCHECK\`, and a CI build-smoke job with an NFR-2 image-size guard.

### What's in this PR (four atomic commits)

- **\`feat(docker):\`** — multi-stage \`Dockerfile\` (python:3.12-slim builder + runtime), \`uv:0.10\` from ghcr.io/astral-sh, \`UV_COMPILE_BYTECODE=1\`, two-step sync for layer-cache friendliness (deps first, source second), non-root user at UID/GID 65532. \`HEALTHCHECK\` polls \`/metrics\` via stdlib \`urllib\` (no \`curl\` in slim, no extra dep). OCI image labels populated. \`.dockerignore\` updated so \`README.md\` and \`LICENSE\` reach hatchling at wheel-build time but not the runtime layer. **Local build: 49 MB compressed; CI build: 54 MB compressed.**
- **\`feat(docker):\`** — \`docker-compose.yml\` with top-level \`name:\`, map-syntax \`environment:\`, port bind on \`127.0.0.1:9100\`, \`json-file\` logging with rotation. \`docker compose config\` validated.
- **\`ci:\`** — \`docker-build\` job runs in parallel with the existing four jobs, builds with GHA layer cache, smoke-tests \`--version\` and \`probe --help\`, and **fails CI if compressed image size exceeds 80 MB** so a future dependency creep is loud rather than silent.
- **\`docs:\`** — README container-deployment section, corrected feature bullet (\`python:3.12-slim runtime\` rather than \`distroless\` -- distroless 3.12 is a Phase-10 hardening target).

### Why python:3.12-slim and not distroless

\`gcr.io/distroless/python3-debian12:nonroot\` ships Debian 12's system Python (3.11). The codebase pins \`requires-python = ">=3.12"\` and uses 3.11/3.12-only APIs (\`asyncio.TaskGroup\`, etc.). Slim keeps the attack surface small without an interpreter mismatch. The decision is documented in the Dockerfile header.

### CI image-size enforcement

\`\`\`
compressed image size: 54 MB
\`\`\`

The build job runs \`docker save | gzip -1 | wc -c\` and fails with \`::error::\` if the result exceeds the NFR-2 ceiling. Locks the project requirement into the pipeline.

### What's NOT in this PR

- **Multi-arch (\`linux/arm64\`) build.** Lives in Phase 10's release workflow because QEMU-based arm64 builds run 3-5x slower than native amd64 and would dominate every CI cycle for feedback the release path covers anyway.
- **Push to ghcr.io.** Same reason: Phase 10. The \`docker-compose.yml\` references the future image path so deploying \`docker compose up -d\` works once the registry is populated.

### Quality gates

| Gate | CI |
|---|---|
| \`ruff check\` / \`format\` | ✅ |
| \`mypy --strict\` | ✅ |
| \`pytest\` 339 tests on 3.12 + 3.13 | ✅ |
| Docker build (linux/amd64) | ✅ |
| Image size guard (≤ 80 MB compressed) | ✅ 54 MB |

## Test plan

- [x] All five CI jobs green on first push.
- [x] \`docker build .\` completes locally (~70 s clean, layer-cache makes incremental builds <10 s).
- [x] \`docker run --rm <image> --version\` returns \`ez1-bridge 0.0.0\`.
- [x] \`docker run --rm <image> probe --help\` reachable.
- [x] \`docker compose config\` renders valid YAML with env-var substitution.
- [x] Image size 54 MB compressed (NFR-2: ≤ 80 MB).
- [ ] Reviewer confirms commit history has no AI attribution.