### PR TITLE
Phase 8 — CI/CD hardening: release.yml, CodeQL, setup-uv v7, branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+# CodeQL is a slow scan (~5-10 min for this codebase). Run it on a
+# weekly schedule plus on direct pushes to main and develop -- not on
+# every PR -- so the per-PR feedback loop stays fast. Security findings
+# discovered against develop are still surfaced early in the
+# integration window before they reach main, which is the right
+# trade-off for a small team.
+#
+# CodeQL is intentionally NOT a required status check on main: a
+# weekly cron failing should not retroactively block the merge queue.
+# Findings open advisories that get triaged on their own cadence.
+
+on:
+  push:
+    branches: [main, develop]
+  schedule:
+    # Mondays at 04:00 UTC -- well clear of business hours, doesn't
+    # collide with the typical Sunday-evening release window.
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (python)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          # Use the curated default query suite; we have not seen any
+          # noisy false positives that would justify a custom config
+          # yet. Re-evaluate when the codebase doubles in size.
+          queries: security-and-quality
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:python'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+# Triggered by:
+#   * a tag push matching v*  -> full release: build, push to GHCR,
+#     generate SBOM, create GitHub Release with notes + SBOM attached.
+#   * workflow_dispatch with dry_run=true (default) -> build only;
+#     skip the push, the SBOM, and the release-creation steps so the
+#     workflow can be exercised against develop without producing
+#     side effects.
+#
+# Why push:tags and not release:published:
+#   The release: trigger requires the GitHub Release to exist *before*
+#   the workflow runs, which forces a two-step manual process (create
+#   empty release -> wait for assets -> attach manually). Tag-driven
+#   release lets a single 'git tag vX.Y.Z && git push origin vX.Y.Z'
+#   produce a complete release atomically.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Skip image push, SBOM, and release creation (default: true)"
+        type: boolean
+        default: true
+
+# Concurrency: never run two release builds for the same ref in
+# parallel. They would race on the GHCR tag and on the Release object.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create the GitHub Release + upload assets
+  packages: write   # push to ghcr.io/baronblk/ez1-mqtt-bridge
+  id-token: write   # SLSA provenance future-proofing
+
+jobs:
+  release:
+    name: Build, push, release
+    runs-on: ubuntu-latest
+    env:
+      # Single source of truth for "should we actually publish?".
+      # Tag-push always publishes; manual run respects the dry_run input.
+      PUBLISH: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # QEMU enables emulated arm64 builds on the amd64 GitHub runner.
+      # Slow (~3-5x native) but acceptable for a release-time workflow
+      # that runs once per tag, not on every PR.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Compute the tag set: vX.Y.Z, X.Y.Z, X.Y, plus :latest on tag pushes.
+      - name: Resolve image tags and OCI labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Login to GHCR
+        if: env.PUBLISH == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and push) multi-arch image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ env.PUBLISH == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Generate SPDX SBOM via syft
+        if: env.PUBLISH == 'true'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Create GitHub Release with auto-generated notes + SBOM
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            sbom.spdx.json
+          body: |
+            Multi-arch image: `ghcr.io/${{ github.repository }}:${{ github.ref_name }}`
+            (linux/amd64, linux/arm64)
+
+            Pull with:
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ```
+
+            SBOM in SPDX-JSON format is attached as `sbom.spdx.json`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,14 +1,133 @@
 # Architecture
 
-> **Status:** placeholder — populated in Phase 9.
+> Component diagrams and runtime sequences will arrive in Phase 9 once
+> the system has settled. This document already covers the parts that
+> change rarely and that contributors need to know up front: how the
+> repository is laid out, which CI/CD workflows guard merges, and which
+> branch-protection rules the maintainer enforces.
 
-Will contain:
+## Repository layout
 
-- High-level component diagram (Mermaid).
-- Sequence diagram for the poll loop and command dispatch path.
-- Concurrency model (`asyncio.TaskGroup`, four coroutines, graceful shutdown).
-- Resilience matrix (failure mode → expected behavior).
-- Deployment topology in the target homelab.
+```
+src/ez1_bridge/
+├── adapters/         # I/O layer (httpx, aiomqtt, prometheus_client, aiohttp)
+│   ├── ez1_http.py        # EZ1 local HTTP API client
+│   ├── mqtt_publisher.py  # aiomqtt publisher with LWT and reconnect hook
+│   └── prom_metrics.py    # MetricsRegistry + /metrics aiohttp server
+├── application/      # Coroutines + glue, no transport details
+│   ├── command_handler.py # set/+ subscriber and dispatcher
+│   ├── ha_discovery.py    # table-driven HA discovery payload builder
+│   └── poll_service.py    # poll_loop, availability_heartbeat, _wait_or_stop
+├── domain/           # Pure logic, no I/O dependencies (100% test coverage)
+│   ├── models.py         # frozen Pydantic v2 models for inverter state
+│   └── normalizer.py     # raw EZ1 envelope -> InverterState
+├── config.py         # pydantic-settings, env-driven Settings
+├── logging_setup.py  # structlog config, TTY-aware JSON/text resolver
+├── main.py           # entrypoint, signal handling, run_service TaskGroup
+├── topics.py         # centralised MQTT topic builders + RETAIN map
+└── __main__.py       # 'python -m ez1_bridge' shim
+```
 
-For now, the architectural source of truth is the project root `CLAUDE.md`
-and the original Claude Code prompt that bootstrapped the repository.
+The Clean-Architecture-light split (adapters / application / domain) is
+load-bearing: domain has no I/O imports, application depends on
+adapters, the wiring lives in `main.run_service`. Tests can exercise
+the domain layer at full coverage without touching network or filesystem.
+
+## CI/CD workflows
+
+Three GitHub Actions workflows live under `.github/workflows/`:
+
+| Workflow      | Trigger                                                | Purpose                                              |
+|---------------|--------------------------------------------------------|------------------------------------------------------|
+| `ci.yml`      | push to `main` / `develop` / `feature/**`, PRs         | Lint, type-check, test (3.12 + 3.13), Docker smoke   |
+| `release.yml` | tag push matching `v*`, manual `workflow_dispatch`     | Multi-arch image build, GHCR push, SBOM, GH release  |
+| `codeql.yml`  | push to `main` / `develop`, weekly cron, manual run    | Python security scanning via CodeQL                  |
+
+### `ci.yml` jobs
+
+| Job                                | Required for `main` merge | Notes                                            |
+|------------------------------------|---------------------------|--------------------------------------------------|
+| `Lint (ruff)`                      | yes                       | `ruff check` + `ruff format --check`             |
+| `Type check (mypy --strict)`       | yes                       | Whole `src` + `tests` tree                       |
+| `Test (Python 3.12)`               | yes                       | pytest with global ≥85% coverage gate            |
+| `Test (Python 3.13)`               | yes                       | Same suite on 3.13 for forward-compat            |
+| `Docker build smoke (linux/amd64)` | yes (Phase 8 onwards)     | `--version` + `probe --help` + ≤80 MB size guard |
+
+Every test job also enforces 100% line+branch coverage on
+`src/ez1_bridge/domain/` via a follow-up `coverage report --include`
+step -- the domain layer is pure logic, anything below 100% is a
+missed test, not a quirk.
+
+### `release.yml` pipeline
+
+Triggered exclusively by a tag push matching `v*` (atomic release in
+one shot) or by a manual `workflow_dispatch` with the default
+`dry_run=true` (build only, no push, no release-asset upload). The
+release path:
+
+1. QEMU + Buildx so a single amd64 runner can produce `linux/arm64`
+   images (~3-5x native speed; acceptable once per tag).
+2. `docker/metadata-action` computes the tag set:
+   `vX.Y.Z`, `X.Y.Z`, `X.Y`, plus `:latest` on real tag pushes.
+3. Login to `ghcr.io` via `GITHUB_TOKEN` (no PAT needed -- the token
+   has `packages:write` for the same repository's namespace).
+4. `docker/build-push-action@v6` builds and pushes the multi-arch
+   image, including signed provenance and SBOM attestations.
+5. `anchore/sbom-action` generates an SPDX-JSON SBOM via Syft.
+6. `softprops/action-gh-release` publishes the GitHub Release with
+   auto-generated notes and the SBOM attached.
+
+### `codeql.yml` cadence
+
+CodeQL runs on direct pushes to `main` / `develop` and weekly on a
+Monday-04:00 UTC cron. It is intentionally **not** on PRs: a 5-10 min
+analysis would dominate per-PR feedback latency for findings that are
+still caught when the same code lands on `develop`.
+
+CodeQL is also intentionally **not** a required status check on
+`main`. A weekly cron failure should not retroactively block the
+merge queue; findings open advisories that are triaged independently.
+
+## Branch protection
+
+| Setting                              | `main`              | `develop`         |
+|--------------------------------------|---------------------|-------------------|
+| Require PR before merging            | ✅                  | ❌                |
+| Required approving reviews           | 0 (solo repo)       | —                 |
+| Require status checks to pass        | ✅                  | ❌                |
+| Required checks (strict)             | 5 (see below)       | —                 |
+| `enforce_admins`                     | ✅                  | ❌                |
+| Require conversation resolution      | ✅                  | ❌                |
+| `allow_force_pushes`                 | ❌                  | ✅                |
+| `allow_deletions`                    | ❌                  | ✅                |
+
+Required status checks on `main`:
+
+1. `Lint (ruff)`
+2. `Type check (mypy --strict)`
+3. `Test (Python 3.12)`
+4. `Test (Python 3.13)`
+5. `Docker build smoke (linux/amd64)`
+
+`develop` is intentionally permissive so the maintainer can rebase /
+amend / squash freely during integration; `main` is the protected
+canonical branch that mirrors the latest tagged release.
+
+The protection rules are managed via the GitHub REST API rather than
+the web UI. The single source of truth for the rule set is the
+JSON document committed at `docs/_reference/branch-protection-main.json`
+(see Phase 9 for the planned export tooling). For now, the
+canonical rule set is reproduced here in human-readable form.
+
+## Workflows that are deliberately absent
+
+* **Auto-merge for Dependabot PRs.** Phase 9 introduces `dependabot.yml`,
+  but auto-merge stays opt-in -- our small dependency graph deserves a
+  human glance before a transitive update lands.
+* **Coverage upload to Codecov / SonarCloud.** Coverage is enforced
+  inside the CI job (`fail_under`) and the report is dumped to the
+  job log. A third-party analytics service is not yet justified.
+* **Image signing via cosign.** Phase 10 stretch goal: today's SBOM +
+  Buildx-native provenance is already a meaningful supply-chain
+  signal; cosign keyless signatures with the OIDC token would be the
+  next step.


### PR DESCRIPTION
## Summary

Closes the CI/CD picture: tag-driven release pipeline with multi-arch image, GHCR push, SBOM, and dry-run mode; weekly Python security scanning via CodeQL; bumped \`setup-uv\` to v7 ahead of GitHub's Node.js 20 deprecation; branch-protection update so the Phase-7 \`Docker build smoke\` job is now a required check on \`main\`; and a substantive \`docs/architecture.md\` that captures the rules in versionable Markdown rather than tribal knowledge.

### What's in this PR (four atomic commits)

- **\`ci:\`** — \`astral-sh/setup-uv\` bumped from v6 to v7 (Node.js 22 base) so the runners do not start force-running our actions on a Node.js version we did not opt into.
- **\`ci:\`** — \`codeql.yml\` for Python security scanning. Triggers: push to \`main\`/\`develop\`, weekly Monday 04:00 UTC cron, manual dispatch. **Not on PRs** because a 5-10 min analysis would dominate per-PR feedback. **Not a required status check** because a weekly cron failure should not retroactively block the merge queue.
- **\`ci:\`** — \`release.yml\` triggered by tag push (\`v*\`) or manual dispatch with \`dry_run\` (default true). Builds multi-arch (\`linux/amd64\`, \`linux/arm64\`) via QEMU, pushes to \`ghcr.io/baronblk/ez1-mqtt-bridge\` with the \`v*\`/\`X.Y.Z\`/\`X.Y\`/\`latest\` tag set from \`docker/metadata-action\`, generates SPDX-JSON SBOM via \`anchore/sbom-action\` (Syft), and creates the GitHub Release with auto-generated notes plus the SBOM attached. Auth via \`GITHUB_TOKEN\` only -- no PAT.
- **\`docs(architecture):\`** — full repository-layout + CI-workflow + branch-protection documentation. Markdown tables for the rule set so the doc survives GitHub UI changes; explicit list of workflows that are intentionally absent (auto-merge, Codecov, cosign) with rationale so future contributors do not re-litigate.

### Branch protection update

Applied via \`gh api -X PUT /repos/baronblk/ez1-mqtt-bridge/branches/main/protection\`. \`Docker build smoke (linux/amd64)\` is now the fifth required status check on \`main\`. Existing rules unchanged: \`enforce_admins=true\`, \`allow_force_pushes=false\`, \`allow_deletions=false\`, \`required_conversation_resolution=true\`.

### Why \`push: tags\` and not \`release: published\`

Documented inline in \`release.yml\`. Short version: \`release:published\` requires the GitHub Release to exist before the workflow runs, forcing a two-step manual dance. Tag-driven release lets a single \`git tag vX.Y.Z && git push origin vX.Y.Z\` produce a complete release atomically.

### Quality gates

| Gate | CI |
|---|---|
| \`ruff check\` / \`format\` | ✅ |
| \`mypy --strict\` | ✅ |
| \`pytest\` 339 tests on 3.12 + 3.13 | ✅ |
| Docker build (linux/amd64) | ✅ |
| Image size guard (≤ 80 MB compressed) | ✅ |

CodeQL workflow has not yet run on \`develop\` (will fire on the post-merge push); release.yml has not been exercised end-to-end (waits for Phase 10's \`v0.1.0\` tag).

## Test plan

- [x] All 5 required checks green on first push.
- [x] \`setup-uv@v7\` migration works without further config changes.
- [x] Branch protection on \`main\` reflects the 5-check set (verified via \`gh api\`).
- [x] \`release.yml\` workflow_dispatch will be smoke-tested with \`dry_run=true\` after merge to validate the build path without producing GHCR artefacts.
- [ ] Reviewer confirms commit history has no AI attribution.