### PR TITLE
Phase 9 — User-facing documentation finalized for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,125 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - TBD
+
+Initial release of the ez1-mqtt-bridge service.
+
 ### Added
 
-- Initial repository scaffolding (Phase 0): `uv` project layout, ruff + mypy +
-  pytest configuration, pre-commit hooks, GitHub Actions CI workflow.
-- Reference documentation for the APsystems EZ1 local API
-  (`docs/_reference/apsystems-ez1-local-api.md`).
+#### Inverter integration
 
-[Unreleased]: https://github.com/baronblk/ez1-mqtt-bridge/compare/HEAD
+- Async HTTP client for the APsystems EZ1-M local API on TCP/8050,
+  covering all seven endpoints (`getDeviceInfo`, `getOutputData`,
+  `getMaxPower`, `setMaxPower`, `getAlarm`, `getOnOff`, `setOnOff`).
+- Explicit retry classifier: timeouts and 5xx retry with exponential
+  backoff (1 s / 2 s / 4 s, capped at 300 s, three attempts);
+  `ConnectError` and 4xx fail fast.
+- Connection-pooled `httpx.AsyncClient` reused across the bridge's
+  lifetime so TCP keep-alive amortises the WLAN round-trip.
+
+#### MQTT publishing
+
+- `aiomqtt` publisher with LWT preset on the availability topic
+  (`offline` retained on ungraceful disconnect) and an explicit
+  `availability=offline` publish on graceful shutdown.
+- Centralised topic builders in `src/ez1_bridge/topics.py` with a
+  machine-readable `RETAIN` map -- the publisher reads the map
+  directly, no scattered hard-coded retain flags.
+- Structured JSON state topic plus 16 retained flat per-metric
+  topics for non-JSON consumers.
+- Generic `publish(topic, payload, *, retain, qos)` for arbitrary
+  topics (used by HA discovery), `publish_state` / `publish_result`
+  / `publish_availability` typed convenience methods.
+
+#### Home Assistant auto-discovery
+
+- 11 sensors and 4 binary sensors auto-discovered as one device card.
+- Table-driven payload builder over `_SENSOR_SPECS` and
+  `_BINARY_SENSOR_SPECS` -- adding a new HA field is a column in a
+  tuple, not a refactor.
+- Discovery refresh on first successful poll and every 24 h to
+  track `getDeviceInfo` changes (firmware upgrades, IP changes).
+
+#### Command handler
+
+- Three-layer validation pipeline for `set/+` commands: topic parse
+  → payload parse (rejects empty, units, decimals, non-numeric) →
+  range check against the live `DeviceInfo.min_power_w` /
+  `max_power_w` bounds.
+- Optional read-back verify after `setMaxPower` writes (default on);
+  `EZ1_BRIDGE_SETMAXPOWER_VERIFY=false` for fire-and-forget.
+- Stable `error` codes on the result topic (`invalid_payload`,
+  `out_of_range`, `transport_error`, `verify_mismatch`) for HA
+  automations to match against.
+
+#### Observability
+
+- 11 Prometheus metric families covering bridge liveness, per-channel
+  power and energy gauges, alarm bits, API request duration histogram
+  with WLAN-tuned buckets (25 ms-5 s), API error counter labelled by
+  exception class, MQTT publish counter labelled by topic kind, MQTT
+  reconnect counter.
+- `aiohttp` server on `:9100/metrics` with the
+  `prometheus-client.CONTENT_TYPE_LATEST` content type. Doubles as
+  the container's healthcheck.
+- `MetricsRegistry` owns its own `CollectorRegistry` -- two instances
+  in the same process do not collide, which makes test isolation
+  trivial.
+- structlog configuration with TTY-aware format resolver: JSON in
+  containers (no TTY), ANSI-coloured `ConsoleRenderer` in dev
+  terminals.
+
+#### Orchestration
+
+- Single `asyncio.TaskGroup` in `run_service` coordinating four
+  sibling coroutines: poll loop, availability heartbeat,
+  `/metrics` server, command handler.
+- Graceful `SIGINT` / `SIGTERM` handling via a shared `asyncio.Event`;
+  the command-loop iterator (which blocks on `async for`) is broken
+  via explicit `task.cancel()` from the parent coroutine.
+- Resolves `device_id` via `getDeviceInfo` before bringing up MQTT so
+  the LWT topic baked into CONNECT is correct from the first packet.
+
+#### Containerisation
+
+- Multi-stage Dockerfile: `python:3.12-slim` builder with
+  `uv:0.10` from `ghcr.io/astral-sh`, `python:3.12-slim` runtime
+  with a non-root user (UID/GID 65532, mirrors the
+  distroless-nonroot convention for a future migration).
+- `UV_COMPILE_BYTECODE=1` so first-import has no compile path; only
+  `/app/.venv` and `/app/src` cross the stage boundary.
+- `/metrics`-based `HEALTHCHECK` via stdlib `urllib` -- no `curl`
+  dependency, no extra layer. Healthcheck stays green when the
+  inverter is night-offline (the bridge is the thing being checked,
+  not the inverter).
+- Multi-arch image (`linux/amd64`, `linux/arm64`) at
+  `ghcr.io/baronblk/ez1-mqtt-bridge`. Compressed image size ~50 MB
+  (NFR-2 ceiling: 80 MB, enforced as a CI gate).
+- `docker-compose.yml` in Dockhand style with map-syntax env, port
+  bind on `127.0.0.1:9100` only, JSON-file logging with rotation.
+
+#### Quality gates
+
+- `ruff` (full PL-rule set), `mypy --strict`, `pytest` with
+  `pytest-asyncio` and `respx`, `bandit`, `pip-audit`,
+  `pre-commit` with conventional-commit enforcement via
+  `commitizen`, `testcontainers` for real-broker integration tests.
+- 339 tests covering unit and integration paths; 100 % coverage on
+  the `domain/` layer (lines + branches), 98 %+ overall.
+- GitHub Actions: lint, type check, test (Python 3.12 + 3.13),
+  Docker build smoke with image-size guard, weekly CodeQL scan,
+  tag-triggered release with multi-arch image, GHCR push, SBOM
+  attached to the GitHub release.
+
+#### Documentation
+
+- `docs/architecture.md`, `docs/mqtt-topics.md`,
+  `docs/home-assistant.md`, `docs/api-reference.md`, plus the
+  hand-curated EZ1 local-API reference at
+  `docs/_reference/apsystems-ez1-local-api.md`.
+- README with feature list, badges, configuration table, and CLI
+  reference.
+
+[Unreleased]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/baronblk/ez1-mqtt-bridge/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,43 +1,54 @@
 # ez1-mqtt-bridge
 
 [![CI](https://github.com/baronblk/ez1-mqtt-bridge/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/baronblk/ez1-mqtt-bridge/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/baronblk/ez1-mqtt-bridge?include_prereleases&sort=semver)](https://github.com/baronblk/ez1-mqtt-bridge/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.12%20%7C%203.13-blue.svg)](https://www.python.org/)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
-Async Python service that bridges the **APsystems EZ1-M** micro inverter's local
-HTTP API to MQTT, with native Home Assistant auto-discovery and Prometheus metrics.
+Async Python service that bridges the **APsystems EZ1-M** micro
+inverter's local HTTP API to MQTT, with native Home Assistant
+auto-discovery and Prometheus metrics.
 
-> **Status:** in development. Initial release `v0.1.0` is tracked under
-> [milestones](https://github.com/baronblk/ez1-mqtt-bridge/milestones). The
-> active development branch is `develop`; `main` mirrors the latest tagged release.
+## Features
 
-## Features (target for `v0.1.0`)
-
-- Polls the EZ1 local API on TCP/8050 every 20 s (configurable).
-- Publishes a structured JSON state topic plus flat per-metric topics, retained.
-- Sends Home Assistant MQTT discovery on first successful poll (11 sensors,
-  4 binary sensors).
-- Accepts MQTT command topics for `setMaxPower` and `setOnOff` with result topics.
-- Exposes Prometheus metrics on `:9100/metrics`.
-- Survives nightly inverter offline windows, MQTT disconnects, and bridge restarts
-  via LWT and exponential backoff.
-- Multi-arch Docker image (`linux/amd64`, `linux/arm64`), `python:3.12-slim`
-  runtime as a non-root user. Image size approx. 50 MB compressed.
-
-## Tech stack
-
-Python 3.12+ · `httpx` · `aiomqtt` · `pydantic` v2 · `structlog` ·
-`prometheus-client` · `aiohttp` · `uv` · `ruff` · `mypy --strict` · `pytest`.
+- **Local-only.** Talks to the EZ1's HTTP API on TCP/8050; no cloud
+  dependencies and no third-party telemetry.
+- **State on MQTT.** Structured JSON state topic plus 16 flat
+  per-metric topics, all retained so a fresh subscriber gets the
+  current snapshot immediately.
+- **Home Assistant auto-discovery.** 11 sensors and 4 binary sensors
+  appear automatically as one device card on first connect; refreshed
+  every 24 h to track firmware-version changes.
+- **Bidirectional control.** Accepts `set/max_power` and `set/on_off`
+  MQTT commands with three-layer validation (topic / payload / range)
+  and structured result payloads with stable error codes for HA
+  automations to match against.
+- **Read-back verify.** A `setMaxPower` write is followed by a 2-second
+  read-back; the result topic surfaces a `verify_mismatch` event if
+  the inverter silently rejected the value. Configurable via
+  `EZ1_BRIDGE_SETMAXPOWER_VERIFY`.
+- **Prometheus on `/metrics`.** Eleven metric families covering
+  bridge liveness, per-channel power and energy gauges, alarm bits,
+  API request histograms with WLAN-tuned buckets, MQTT publish/
+  reconnect counters.
+- **Resilient.** Survives nightly inverter offline windows
+  (`availability=offline`, no crash), MQTT disconnects (LWT-driven
+  graceful shutdown), and bridge restarts. Explicit `offline` publish
+  on graceful shutdown so HA's availability badge does not lie.
+- **Container-native.** Multi-arch image (`linux/amd64`,
+  `linux/arm64`) on `python:3.12-slim`, runs as a non-root user,
+  ~50 MB compressed. `/metrics`-based healthcheck with stdlib
+  `urllib` -- no extra dependencies.
 
 ## Documentation
 
-- [`docs/_reference/apsystems-ez1-local-api.md`](docs/_reference/apsystems-ez1-local-api.md)
-  — full reference for all seven EZ1 endpoints, including verified payloads and
-  empirical edge cases.
-- `docs/architecture.md`, `docs/mqtt-topics.md`, `docs/home-assistant.md` —
-  populated in Phase 9.
+| Document | Purpose |
+|----------|---------|
+| [`docs/architecture.md`](docs/architecture.md) | Repository layout, CI/CD workflows, branch protection |
+| [`docs/mqtt-topics.md`](docs/mqtt-topics.md) | Every published / subscribed / discovery topic with payload schemas |
+| [`docs/home-assistant.md`](docs/home-assistant.md) | Integration guide with copy-paste automation examples |
+| [`docs/api-reference.md`](docs/api-reference.md) | EZ1 endpoint summary + firmware compatibility |
+| [`docs/_reference/apsystems-ez1-local-api.md`](docs/_reference/apsystems-ez1-local-api.md) | Canonical local-API reference (verified payloads + edge cases) |
 
 ## Container deployment
 
@@ -46,21 +57,23 @@ Python 3.12+ · `httpx` · `aiomqtt` · `pydantic` v2 · `structlog` ·
 cp .env.example .env
 $EDITOR .env
 
-# Bring up the bridge (uses ghcr.io/baronblk/ez1-mqtt-bridge once Phase 10 publishes)
+# Bring up the bridge
 docker compose up -d
 
 # Tail logs
 docker compose logs -f bridge
 
-# Shut down cleanly (LWT triggers + explicit availability=offline publish)
+# Shut down cleanly (explicit availability=offline publish before disconnect)
 docker compose down
 ```
 
-The `/metrics` endpoint binds to `0.0.0.0:9100` inside the container and is
-forwarded to `127.0.0.1:9100` on the host -- intended for a Prometheus scraper
-on the same host or co-located in the `ez1-bridge-net` Docker network.
-Healthcheck pulls `/metrics` once every 30 s and stays green even when the
-inverter is night-offline.
+The `/metrics` endpoint binds to `0.0.0.0:9100` inside the container
+and is forwarded to `127.0.0.1:9100` on the host -- intended for a
+Prometheus scraper on the same host or co-located in the
+`ez1-bridge-net` Docker network. The healthcheck polls `/metrics`
+every 30 s and stays green when the inverter is night-offline (the
+bridge stays healthy; the inverter is what's missing, surfaced via
+`availability=offline`).
 
 To build the image locally instead of pulling:
 
@@ -69,29 +82,71 @@ docker build -t ez1-mqtt-bridge:local .
 docker run --rm ez1-mqtt-bridge:local --version
 ```
 
+## Configuration
+
+All settings flow through environment variables prefixed with
+`EZ1_BRIDGE_`. Copy [`.env.example`](.env.example) to `.env` and
+edit. The required minimum is `EZ1_BRIDGE_EZ1_HOST` and
+`EZ1_BRIDGE_MQTT_HOST`; everything else has a sensible default.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EZ1_BRIDGE_EZ1_HOST` | (required) | Inverter IP or hostname |
+| `EZ1_BRIDGE_EZ1_PORT` | `8050` | Inverter HTTP port |
+| `EZ1_BRIDGE_POLL_INTERVAL` | `20` | Seconds between poll cycles |
+| `EZ1_BRIDGE_REQUEST_TIMEOUT` | `5` | Per-request HTTP timeout, seconds |
+| `EZ1_BRIDGE_SETMAXPOWER_VERIFY` | `true` | Read-back verify after setMaxPower writes |
+| `EZ1_BRIDGE_MQTT_HOST` | (required) | MQTT broker IP or hostname |
+| `EZ1_BRIDGE_MQTT_PORT` | `1883` | MQTT broker port |
+| `EZ1_BRIDGE_MQTT_USER` | _empty_ | MQTT username (optional) |
+| `EZ1_BRIDGE_MQTT_PASSWORD` | _empty_ | MQTT password (optional, treated as `SecretStr`) |
+| `EZ1_BRIDGE_MQTT_BASE_TOPIC` | `ez1` | Topic root |
+| `EZ1_BRIDGE_MQTT_DISCOVERY_PREFIX` | `homeassistant` | HA discovery prefix |
+| `EZ1_BRIDGE_METRICS_BIND` | `0.0.0.0` | `/metrics` bind address |
+| `EZ1_BRIDGE_METRICS_PORT` | `9100` | `/metrics` port |
+| `EZ1_BRIDGE_LOG_LEVEL` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` |
+| `EZ1_BRIDGE_LOG_FORMAT` | `auto` | `auto` (TTY → text, else JSON), `json`, `text` |
+
+## CLI
+
+The container's entrypoint is `python -m ez1_bridge`, with two
+subcommands plus `--version`:
+
+```bash
+# Run the bridge service (default)
+python -m ez1_bridge run
+
+# Read-only health check (the same path the Docker HEALTHCHECK uses
+# in spirit, but querying the EZ1 directly)
+python -m ez1_bridge probe --host 192.168.3.24 --json
+
+# Print version and exit
+python -m ez1_bridge --version
+```
+
 ## Development
 
 Requires Python 3.12+ and [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-# Install dependencies into the project venv
-uv sync
-
-# Run the quality gates locally (matches CI)
-uv run ruff check .
-uv run ruff format --check .
-uv run mypy src tests
-uv run pytest
-
-# Install pre-commit hooks (once per clone)
+uv sync                              # install deps into .venv
+uv run ruff check .                  # lint
+uv run ruff format --check .         # format check
+uv run mypy src tests                # type check
+uv run pytest                        # run all tests (~339 tests, ~20 s)
 uv run pre-commit install --install-hooks --hook-type pre-commit --hook-type commit-msg
 ```
 
-> **macOS + exFAT note:** if your project lives on an exFAT-formatted drive,
-> set `UV_PROJECT_ENVIRONMENT=$HOME/Library/Caches/ez1-mqtt-bridge-venv` before
-> running `uv sync`. Apple Double resource forks on exFAT break wheel
-> installation for some packages (e.g. bandit) when the venv lives on the same
-> filesystem.
+Integration tests under `tests/integration/` spin up an
+`eclipse-mosquitto:2.0.20` container via `testcontainers`; they skip
+automatically if Docker is unavailable.
+
+> **macOS + exFAT note:** if your project lives on an exFAT-formatted
+> drive, set
+> `UV_PROJECT_ENVIRONMENT=$HOME/Library/Caches/ez1-mqtt-bridge-venv`
+> before running `uv sync`. Apple Double resource forks on exFAT break
+> wheel installation for some packages (e.g. bandit) when the venv
+> lives on the same filesystem.
 
 ## License
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,16 +1,76 @@
-# EZ1 API Reference
+# EZ1 Local API Reference
 
-> **Status:** placeholder — populated in Phase 9.
-
-The canonical, hand-authored EZ1 local-API reference lives at
+The canonical, hand-authored EZ1 local-API reference is at
 [`_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md).
-That document is the source of truth for endpoint shapes, verified payloads,
-edge cases, and polling recommendations.
+That file is the source of truth for endpoint shapes, verified
+real-world payloads, edge cases (inverted on/off semantics,
+string-encoded watt values), and the polling recommendations the
+bridge follows.
 
-This file will eventually consolidate:
+## Where to use which document
 
-- A short overview pointing readers at the reference document.
-- A summary of the seven endpoints in the form Claude / contributors expect
-  when working in `src/ez1_bridge/adapters/ez1_http.py`.
-- Notes on firmware-version compatibility once we test against more than the
-  current `EZ1 1.12.2t` build.
+| You want to...                                    | Read                                                   |
+|---------------------------------------------------|--------------------------------------------------------|
+| Know what the inverter answers and how            | [`_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md) |
+| Know what topics the bridge produces or consumes  | [`mqtt-topics.md`](mqtt-topics.md) |
+| Wire the bridge into Home Assistant               | [`home-assistant.md`](home-assistant.md) |
+| Understand the repo layout, CI, branch protection | [`architecture.md`](architecture.md) |
+
+## Endpoint summary
+
+The bridge talks to seven EZ1 endpoints. All HTTP `GET`, all return
+the same `{"data": {...}, "message": "SUCCESS|FAILED", "deviceId": "..."}`
+envelope.
+
+| Method | Endpoint           | Direction | Use in the bridge                                       |
+|--------|--------------------|-----------|----------------------------------------------------------|
+| GET    | `/getDeviceInfo`   | read      | Resolved at startup + every 24 h to refresh HA discovery |
+| GET    | `/getOutputData`   | read      | Polled every cycle (default 20 s) for instantaneous power and energy |
+| GET    | `/getMaxPower`     | read      | Polled every cycle; used by the verify read-back after `setMaxPower` writes |
+| GET    | `/setMaxPower?p=N` | write     | Issued by the command handler in response to `set/max_power` MQTT messages |
+| GET    | `/getAlarm`        | read      | Polled every cycle for the four diagnostic bits |
+| GET    | `/getOnOff`        | read      | Polled every cycle for the operational on/off state (note inverted wire format) |
+| GET    | `/setOnOff?status=N` | write   | Issued in response to `set/on_off` MQTT messages |
+
+The implementation lives in
+[`src/ez1_bridge/adapters/ez1_http.py`](../src/ez1_bridge/adapters/ez1_http.py)
+with retry classification (timeouts and 5xx retry; `ConnectError` and
+4xx fail fast) and Prometheus instrumentation per call.
+
+## Firmware compatibility
+
+The reference document was authored against firmware **EZ1 1.12.2t**.
+The bridge has not been tested against earlier or later firmware
+versions. If you run a different firmware:
+
+1. Capture the actual payloads with `curl http://<EZ1>:8050/<endpoint>`
+   for each of the seven endpoints.
+2. Diff against the verified payloads in
+   [`_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md).
+3. Open an issue with the diff plus your firmware string from
+   `getDeviceInfo.devVer` if the response shape changed -- the
+   normalizer's defensive parsers will surface drift as
+   `ValueError` instead of silently coercing.
+
+## Empirical edge cases (recap)
+
+A short tour of the surprises the reference document captures in
+detail. The bridge handles all four; this list is here so a
+contributor reading runtime logs knows which behaviour is
+documented vs. unexpected.
+
+* **Inverted on/off semantics.** API `status="0"` means **on**,
+  `"1"` means **off**. The bridge centralises this in a single
+  `_STATUS_MAP` constant in
+  [`src/ez1_bridge/domain/normalizer.py`](../src/ez1_bridge/domain/normalizer.py)
+  so a refactor cannot drift the direction.
+* **`minPower` / `maxPower` arrive as strings.** The bridge parses
+  them through `_to_int_watt` which rejects `"800W"`, `"800.0"`,
+  hex, and other firmware-drift strings.
+* **`e1` / `e2` reset on cold start.** Energy "today" counters are
+  really "since last cold start"; mid-day cloud-induced inverter
+  shutdowns can reset them. Home Assistant's
+  `state_class: total_increasing` handles the resets correctly.
+* **Local API stays reachable when the inverter is `off`.** A
+  `set_on_off(on=False)` does not lock you out -- the bridge can
+  always re-issue `set_on_off(on=True)` to bring output back.

--- a/docs/home-assistant.md
+++ b/docs/home-assistant.md
@@ -1,14 +1,221 @@
 # Home Assistant Integration
 
-> **Status:** placeholder — populated in Phase 9.
+End-to-end guide: get the bridge running, watch Home Assistant
+auto-discover the device, build automations against the published
+state and the writable command topics.
 
-Will contain:
+## Prerequisites
 
-- Step-by-step integration guide (broker config, discovery prefix, network
-  considerations).
-- Screenshot placeholders for the Home Assistant device card with all 11
-  sensors and 4 binary sensors.
-- Example automations: dynamic power throttling, off-grid alerting, daily
-  energy summaries.
-- Troubleshooting: when discovery does not appear, when entities are stale,
-  reading the bridge's `availability` topic.
+* Home Assistant Core / OS / Container with the **MQTT integration**
+  configured against the same Mosquitto the bridge uses.
+* A reachable APsystems EZ1-M with **Local Mode** enabled (see
+  [`_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md#aktivierung)
+  for the exact AP EasyPower Bluetooth ritual).
+* The bridge running -- `docker compose up -d` per the
+  [container deployment section in the README](../README.md#container-deployment).
+
+## What you get
+
+When the bridge starts and the inverter responds to `getDeviceInfo`,
+Home Assistant's MQTT integration auto-creates **one device card with
+fifteen entities**:
+
+| Entity | Type            | Unit  | Source field             |
+|--------|-----------------|-------|--------------------------|
+| Power Channel 1 | sensor    | W     | `power.ch1_w`            |
+| Power Channel 2 | sensor    | W     | `power.ch2_w`            |
+| Power Total     | sensor    | W     | `power.total_w`          |
+| Energy Today Channel 1 | sensor | kWh | `energy_today.ch1_kwh` |
+| Energy Today Channel 2 | sensor | kWh | `energy_today.ch2_kwh` |
+| Energy Today Total     | sensor | kWh | `energy_today.total_kwh` |
+| Energy Lifetime Channel 1 | sensor | kWh | `energy_lifetime.ch1_kwh` |
+| Energy Lifetime Channel 2 | sensor | kWh | `energy_lifetime.ch2_kwh` |
+| Energy Lifetime Total     | sensor | kWh | `energy_lifetime.total_kwh` |
+| Max Power           | sensor (diagnostic) | W | `max_power_w`        |
+| Status              | sensor (diagnostic) | -- | `status`             |
+| Alarm Off Grid      | binary_sensor (problem) | -- | `alarms.off_grid` |
+| Alarm Output Fault  | binary_sensor (problem) | -- | `alarms.output_fault` |
+| Alarm DC1 Short     | binary_sensor (problem) | -- | `alarms.dc1_short` |
+| Alarm DC2 Short     | binary_sensor (problem) | -- | `alarms.dc2_short` |
+
+The `device_class` annotations (`power`, `energy`, `problem`) tell
+Home Assistant how to format values, which icons to use, and which
+dashboard cards to suggest.
+
+## Verify the integration after first start
+
+1. Wait ~30 s after `docker compose up -d` for the first poll cycle
+   to complete and discovery to publish.
+2. In Home Assistant, navigate to *Settings → Devices & Services →
+   MQTT* and look for an `APsystems EZ1 {device_id}` entry.
+3. Click the device card. All 15 entities should appear with
+   non-stale values (`state_class: total_increasing` for energy
+   counters, `measurement` for instantaneous power).
+4. Check **Availability**: the card-level "Available" indicator
+   reads from the bridge's availability topic. If the bridge is
+   stopped or the inverter is night-offline, every entity goes
+   *Unavailable* simultaneously rather than reporting stale values.
+
+If the device does not appear:
+
+* `mosquitto_sub -t "homeassistant/+/{device_id}/+/config" -v` --
+  is discovery actually being published?
+* `docker compose logs bridge | grep ha_discovery_published` --
+  did the bridge log a successful discovery cycle?
+* Toggle the MQTT integration (re-load it) -- HA caches discovery
+  topics on a per-restart basis.
+
+## Automation examples
+
+The examples assume `device_id = "E17010000783"` and `base_topic = "ez1"`
+(the project defaults). Replace with your own values in `.env`.
+
+### Throttle output to 600 W during midday hours
+
+Reduces export to the grid when local consumption is low; useful in
+markets with negative daytime feed-in tariffs or for staying within
+a 600 W grid-connection limit.
+
+```yaml
+automation:
+  - alias: "EZ1 midday throttle"
+    description: "Limit output to 600 W between 11:00 and 14:00"
+    trigger:
+      - platform: time
+        at: "11:00:00"
+    action:
+      - service: mqtt.publish
+        data:
+          topic: "ez1/E17010000783/set/max_power"
+          payload: "600"
+          qos: 1
+
+  - alias: "EZ1 midday throttle release"
+    description: "Restore 800 W after midday window"
+    trigger:
+      - platform: time
+        at: "14:00:00"
+    action:
+      - service: mqtt.publish
+        data:
+          topic: "ez1/E17010000783/set/max_power"
+          payload: "800"
+          qos: 1
+```
+
+### React to a verify_mismatch result
+
+If the inverter silently rejected a `setMaxPower` write (the verify
+read-back returns a different value), surface a notification rather
+than letting the discrepancy hide.
+
+```yaml
+automation:
+  - alias: "EZ1 setMaxPower verify failure"
+    trigger:
+      - platform: mqtt
+        topic: "ez1/E17010000783/result/max_power"
+    condition:
+      - "{{ trigger.payload_json.ok == false and trigger.payload_json.error == 'verify_mismatch' }}"
+    action:
+      - service: notify.mobile_app
+        data:
+          title: "EZ1 inverter rejected throttle"
+          message: >-
+            Tried to set {{ trigger.payload_json.expected }} W,
+            inverter reports {{ trigger.payload_json.actual }} W.
+```
+
+### Power-cap based on house consumption
+
+Combine the bridge with a smart-meter integration so the inverter
+limit follows household demand. (Example assumes a `sensor.house_load_w`
+exists.)
+
+```yaml
+automation:
+  - alias: "EZ1 dynamic cap follows house load"
+    trigger:
+      - platform: state
+        entity_id: sensor.house_load_w
+    action:
+      - service: mqtt.publish
+        data:
+          topic: "ez1/E17010000783/set/max_power"
+          payload: >-
+            {{ [800, [30, states('sensor.house_load_w') | int(0)] | max] | min }}
+          qos: 1
+    mode: queued
+    max: 5
+```
+
+The Jinja clamps the load to `[30, 800]` (the EZ1's documented
+power range) and uses `mode: queued` so a fast burst of changes
+doesn't trample older requests.
+
+### Shut the inverter off on alarm
+
+If any of the four alarm bits flips to `on`, shut the output down
+and notify. Useful for the DC short-circuit alarms which point at
+panel-side faults that you don't want to ignore.
+
+```yaml
+automation:
+  - alias: "EZ1 shut down on alarm"
+    trigger:
+      - platform: state
+        entity_id:
+          - binary_sensor.alarm_dc1_short
+          - binary_sensor.alarm_dc2_short
+        to: "on"
+    action:
+      - service: mqtt.publish
+        data:
+          topic: "ez1/E17010000783/set/on_off"
+          payload: "off"
+          qos: 1
+      - service: notify.mobile_app
+        data:
+          title: "EZ1 alarm fired"
+          message: >-
+            {{ trigger.entity_id }} = on. Inverter has been turned
+            off; investigate the affected DC channel.
+```
+
+The `set/on_off` accepts `on`/`off`/`1`/`0`; the bridge handles the
+EZ1's inverted wire format (`status="0"` = on) so the automation
+stays human-readable.
+
+## Energy dashboard wiring
+
+Home Assistant's **Energy Dashboard** picks up `energy_*` sensors
+automatically when they have `device_class: energy` and
+`state_class: total_increasing`, both of which the bridge sets via
+discovery. Walk through:
+
+1. *Settings → Dashboards → Energy*.
+2. Under *Solar Panels*, *Add solar production*.
+3. Pick `sensor.energy_lifetime_total` (or `sensor.energy_today_total`
+   if you prefer the per-day flavour, but be aware HA computes daily
+   roll-ups itself; using `lifetime_total` plays nicer with the
+   built-in delta calculation).
+
+Energy Dashboard handles the inverter's per-cold-start reset of
+`energy_today` correctly because `state_class: total_increasing`
+tolerates resets to zero.
+
+## Troubleshooting
+
+| Symptom                                  | Likely cause                                                       | Fix |
+|------------------------------------------|--------------------------------------------------------------------|-----|
+| Device doesn't appear in HA             | Discovery prefix mismatch                                          | Check `EZ1_BRIDGE_MQTT_DISCOVERY_PREFIX` matches HA's MQTT discovery prefix (default `homeassistant`) |
+| Entities stuck on "Unavailable"          | Bridge offline or LWT triggered                                    | `docker compose logs bridge`; verify availability topic (`mosquitto_sub -t ez1/+/availability -v`) |
+| `set/max_power` returns `out_of_range`   | Value outside `[30, 800]`                                          | Range comes from `getDeviceInfo`; clamp the automation's input |
+| `set/on_off` returns `invalid_payload`   | Payload neither `on`/`off` nor `1`/`0`                             | Ensure the automation publishes a string, not an int |
+| Energy Dashboard shows zeros at midnight | Using `energy_today_total` which the inverter resets at cold start | Switch to `energy_lifetime_total` (HA computes daily delta) |
+| Discovery doesn't refresh after firmware upgrade | 24 h discovery refresh cadence                              | Restart bridge to force immediate re-publish, or wait |
+
+For deeper debugging, the bridge exposes Prometheus metrics on
+`:9100/metrics` (see `docs/architecture.md` for the metric set).
+`ez1_api_errors_total` and `ez1_mqtt_publish_total` are usually
+the first two metrics to inspect when something looks wrong.

--- a/docs/mqtt-topics.md
+++ b/docs/mqtt-topics.md
@@ -1,15 +1,200 @@
 # MQTT Topic Reference
 
-> **Status:** placeholder — populated in Phase 9.
+Every topic the bridge produces or consumes, the retain flag it sets,
+and the payload shape on the wire. Three sections: *published* (the
+bridge → broker), *subscribed* (broker → bridge), and *Home Assistant
+discovery* (the bridge announces entities).
 
-Will contain:
+The placeholders `{base}` and `{device_id}` are configurable; the
+defaults are `ez1` and the value of `getDeviceInfo.deviceId`
+(e.g. `E17010000783`). The discovery prefix `{discovery_prefix}`
+defaults to `homeassistant`.
 
-- Complete topic table: state (`{base}/{device_id}/state`), flat per-metric
-  topics, command topics (`set/+`), result topics (`result/+`), availability,
-  and Home Assistant discovery.
-- JSON schemas for the structured state payload and the result payloads.
-- Retain / QoS / LWT semantics per topic.
-- Examples using `mosquitto_sub` and `mosquitto_pub`.
+## Published topics
 
-The canonical EZ1 endpoint reference is in
-[`_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md).
+The bridge emits these. Retain semantics flow from
+`src/ez1_bridge/topics.py::RETAIN`; a regression test guards that the
+publisher reads the map directly rather than hard-coding flags.
+
+| Topic                                         | Retain | QoS | Payload | Updated |
+|-----------------------------------------------|:------:|:---:|---------|---------|
+| `{base}/{device_id}/availability`             |  ✅    |  1  | `online` / `offline` | On connect (online), every 30 s heartbeat, LWT (offline) |
+| `{base}/{device_id}/state`                    |  ✅    |  1  | JSON (see schema below) | Every poll cycle (default 20 s) |
+| `{base}/{device_id}/power/ch1_w`              |  ✅    |  1  | float as string, e.g. `"139.0"` | Every poll cycle |
+| `{base}/{device_id}/power/ch2_w`              |  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/power/total_w`            |  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/energy_today/ch1_kwh`     |  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/energy_today/ch2_kwh`     |  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/energy_today/total_kwh`   |  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/energy_lifetime/ch1_kwh`  |  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/energy_lifetime/ch2_kwh`  |  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/energy_lifetime/total_kwh`|  ✅    |  1  | float as string | Every poll cycle |
+| `{base}/{device_id}/max_power_w/value`        |  ✅    |  1  | int as string, e.g. `"800"` | Every poll cycle |
+| `{base}/{device_id}/status/value`             |  ✅    |  1  | `on` / `off` | Every poll cycle |
+| `{base}/{device_id}/alarm/off_grid`           |  ✅    |  1  | `true` / `false` | Every poll cycle |
+| `{base}/{device_id}/alarm/output_fault`       |  ✅    |  1  | `true` / `false` | Every poll cycle |
+| `{base}/{device_id}/alarm/dc1_short`          |  ✅    |  1  | `true` / `false` | Every poll cycle |
+| `{base}/{device_id}/alarm/dc2_short`          |  ✅    |  1  | `true` / `false` | Every poll cycle |
+| `{base}/{device_id}/alarm/any_active`         |  ✅    |  1  | `true` / `false` | Every poll cycle |
+| `{base}/{device_id}/result/max_power`         |  ❌    |  1  | JSON command result (see below) | After every `setMaxPower` write |
+| `{base}/{device_id}/result/on_off`            |  ❌    |  1  | JSON command result | After every `setOnOff` write |
+
+Result topics are **not** retained — they are events, not state. A
+late subscriber should never see a stale write outcome.
+
+### `state` payload schema
+
+```json
+{
+  "ts": "2026-04-26T18:00:00+00:00",
+  "device_id": "E17010000783",
+  "power": {
+    "ch1_w": 139.0,
+    "ch2_w": 65.0,
+    "total_w": 204.0
+  },
+  "energy_today": {
+    "ch1_kwh": 0.28731,
+    "ch2_kwh": 0.42653,
+    "total_kwh": 0.71384
+  },
+  "energy_lifetime": {
+    "ch1_kwh": 87.43068,
+    "ch2_kwh": 111.24305,
+    "total_kwh": 198.67373
+  },
+  "max_power_w": 800,
+  "status": "on",
+  "alarms": {
+    "off_grid": false,
+    "output_fault": false,
+    "dc1_short": false,
+    "dc2_short": false,
+    "any_active": false
+  }
+}
+```
+
+Field types are stable per `src/ez1_bridge/domain/models.py`:
+power and energy values are floats, `max_power_w` is an int,
+`status` is a `Literal["on", "off"]`, alarm bits are bools.
+
+### `result/*` payload schema
+
+Success:
+
+```json
+{
+  "ok": true,
+  "ts": "2026-04-26T18:00:00+00:00",
+  "value": "600"
+}
+```
+
+Failure variants — `error` is one of `invalid_payload`, `out_of_range`,
+`transport_error`, `verify_mismatch`. Stable identifiers are intended
+for Home Assistant automations to match against.
+
+```json
+{"ok": false, "ts": "...", "error": "invalid_payload",  "detail": "expected integer watts, got 'abc'"}
+{"ok": false, "ts": "...", "error": "out_of_range",     "detail": "value 1000 outside [30, 800]"}
+{"ok": false, "ts": "...", "error": "transport_error",  "detail": "ConnectError: ..."}
+{"ok": false, "ts": "...", "error": "verify_mismatch",  "detail": "expected 600, actual 800",
+                                                          "expected": 600, "actual": 800}
+```
+
+## Subscribed topics
+
+The bridge listens on these. Retain is irrelevant on the subscribe
+side — the bridge consumes the message and emits a `result/*` event
+in response.
+
+| Topic                                  | Payload                          | Validation                                   | Result topic                          |
+|----------------------------------------|----------------------------------|----------------------------------------------|---------------------------------------|
+| `{base}/{device_id}/set/max_power`     | integer watts as string, `"600"` | parsed via `int()`; rejected for empties, units, decimals, non-numeric | `{base}/{device_id}/result/max_power` |
+| `{base}/{device_id}/set/max_power`     | range check                      | must be within `[minPower, maxPower]` from `getDeviceInfo` | `result/max_power` with `error=out_of_range` |
+| `{base}/{device_id}/set/on_off`        | `"on"` or `"off"` (case-insensitive); also `"1"`/`"0"` accepted | `parse_on_off_payload`; rejects anything else with `error=invalid_payload` | `{base}/{device_id}/result/on_off` |
+
+A single subscription pattern `{base}/{device_id}/set/+` covers both
+commands. Unknown command names (e.g. `set/foobar`) are logged at
+WARN level and dropped silently — no result topic is emitted.
+
+### Verify read-back
+
+When `EZ1_BRIDGE_SETMAXPOWER_VERIFY=true` (default), the bridge waits
+~2 s after a `setMaxPower` write, re-reads `getMaxPower`, and emits a
+`verify_mismatch` result if the inverter ignored the write. Disable
+this in latency-sensitive automations by setting it to `false`; the
+bridge is then fire-and-forget and a silently rejected write becomes
+invisible to the result topic.
+
+## Home Assistant discovery topics
+
+The bridge auto-publishes 15 entity-config topics under the discovery
+prefix on the first successful poll cycle and re-publishes every 24 h
+(or whenever the `DeviceInfo` changes after a firmware upgrade).
+
+| Component       | Object ID / unique_id                  | State topic              | Notes                              |
+|-----------------|----------------------------------------|--------------------------|------------------------------------|
+| `sensor`        | `ez1_{device_id}_power_ch1`            | `{base}/{device_id}/state` | unit `W`, `device_class=power`     |
+| `sensor`        | `ez1_{device_id}_power_ch2`            | `{base}/{device_id}/state` | unit `W`                           |
+| `sensor`        | `ez1_{device_id}_power_total`          | `{base}/{device_id}/state` | unit `W`                           |
+| `sensor`        | `ez1_{device_id}_energy_today_ch1`     | `{base}/{device_id}/state` | unit `kWh`, `state_class=total_increasing` |
+| `sensor`        | `ez1_{device_id}_energy_today_ch2`     | `{base}/{device_id}/state` | unit `kWh`                         |
+| `sensor`        | `ez1_{device_id}_energy_today_total`   | `{base}/{device_id}/state` | unit `kWh`                         |
+| `sensor`        | `ez1_{device_id}_energy_lifetime_ch1`  | `{base}/{device_id}/state` | unit `kWh`                         |
+| `sensor`        | `ez1_{device_id}_energy_lifetime_ch2`  | `{base}/{device_id}/state` | unit `kWh`                         |
+| `sensor`        | `ez1_{device_id}_energy_lifetime_total`| `{base}/{device_id}/state` | unit `kWh`                         |
+| `sensor`        | `ez1_{device_id}_max_power`            | `{base}/{device_id}/state` | unit `W`, `entity_category=diagnostic` |
+| `sensor`        | `ez1_{device_id}_status`               | `{base}/{device_id}/state` | textual `on`/`off`, `entity_category=diagnostic` |
+| `binary_sensor` | `ez1_{device_id}_alarm_off_grid`       | `{base}/{device_id}/state` | `device_class=problem`             |
+| `binary_sensor` | `ez1_{device_id}_alarm_output_fault`   | `{base}/{device_id}/state` | `device_class=problem`             |
+| `binary_sensor` | `ez1_{device_id}_alarm_dc1_short`      | `{base}/{device_id}/state` | `device_class=problem`             |
+| `binary_sensor` | `ez1_{device_id}_alarm_dc2_short`      | `{base}/{device_id}/state` | `device_class=problem`             |
+
+The discovery config topic for each entry is
+`{discovery_prefix}/{component}/{device_id}/{key}/config`,
+all retained.
+
+Every payload includes a shared `device` block so Home Assistant
+groups all 15 entities under one device card:
+
+```json
+{
+  "identifiers": ["E17010000783"],
+  "manufacturer": "APsystems",
+  "model": "EZ1",
+  "sw_version": "EZ1 1.12.2t",
+  "name": "APsystems EZ1 E17010000783"
+}
+```
+
+The shared `availability_topic` (`{base}/{device_id}/availability`)
+plus `payload_available: "online"` / `payload_not_available: "offline"`
+makes the entire device card unavailable in the UI when the bridge is
+down or the inverter is night-offline.
+
+## Diagnostic helpers
+
+```bash
+# Watch every topic the bridge produces
+mosquitto_sub -h "$MQTT_HOST" -u "$MQTT_USER" -P "$MQTT_PASSWORD" \
+  -t "ez1/#" -v
+
+# Watch only the structured state
+mosquitto_sub -h "$MQTT_HOST" -u "$MQTT_USER" -P "$MQTT_PASSWORD" \
+  -t "ez1/E17010000783/state" -v
+
+# Trigger a max_power write and observe the result
+mosquitto_pub -h "$MQTT_HOST" -u "$MQTT_USER" -P "$MQTT_PASSWORD" \
+  -t "ez1/E17010000783/set/max_power" -m "600" -q 1
+mosquitto_sub -h "$MQTT_HOST" -u "$MQTT_USER" -P "$MQTT_PASSWORD" \
+  -t "ez1/E17010000783/result/max_power" -C 1 -v
+
+# Inspect the discovery payloads HA picked up
+mosquitto_sub -h "$MQTT_HOST" -u "$MQTT_USER" -P "$MQTT_PASSWORD" \
+  -t "homeassistant/+/E17010000783/+/config" -v
+```
+
+The canonical EZ1 endpoint reference (verified payloads, edge cases)
+is in [`_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md).


### PR DESCRIPTION
## Summary

Closes the documentation surface for the v0.1.0 cut. No code changes;
five doc commits replace the Phase-0 placeholders with substantive
guides plus a finalized README and a populated CHANGELOG entry.

### What's in this PR (five atomic commits)

- **\`docs(mqtt-topics):\`** — three tables (published, subscribed, HA discovery) plus the structured-state and result-payload JSON schemas plus diagnostic \`mosquitto_sub\` / \`mosquitto_pub\` snippets. Stable result-error-code list documented as the HA automation match keys.
- **\`docs(home-assistant):\`** — integration guide with verify-after-start checklist, four copy-paste automation examples (midday throttle, verify-mismatch notification, dynamic cap from house load, alarm shutdown), Energy Dashboard wiring, and a six-row troubleshooting table.
- **\`docs(api-reference):\`** — navigation hub pointing at the canonical \`_reference/apsystems-ez1-local-api.md\` plus an endpoint summary table, firmware-compatibility checklist (verified against \`EZ1 1.12.2t\`), and the four empirical edge cases the bridge handles defensively.
- **\`docs(README):\`** — feature list rewritten to substantive descriptions; badge set trimmed from five to four (CI, release, license, Python -- removed the Ruff and Mypy marketing badges); new Documentation cross-link table; complete configuration table; CLI reference section.
- **\`docs(CHANGELOG):\`** — \`[0.1.0]\` section organised by capability bucket (inverter / MQTT / discovery / commands / observability / orchestration / container / quality gates / documentation). Date left as TBD; the release workflow substitutes it on tag.

### Device-ID consistency

Every example across the three new docs uses \`E17010000783\` (the verified test fixture) so a reader copying snippets gets a coherent mental model.

### `release.yml` dry-run note

The Phase-8 release workflow uses \`workflow_dispatch\`, which GitHub registers only on the default branch. Since \`main\` is still at the Phase-0 seed (no merge until Phase 10's deliberate \`v0.1.0\` cut), \`gh workflow run release.yml -f dry_run=true --ref develop\` returns 404. Mitigation: validated \`release.yml\`, \`codeql.yml\`, and \`ci.yml\` statically with \`actionlint\` (clean output, no findings). The end-to-end exercise will land naturally as the actual \`v0.1.0\` tag in Phase 10.

### Quality gates

| Gate | CI |
|---|---|
| \`ruff check\` / \`format\` | ✅ |
| \`mypy --strict\` | ✅ |
| \`pytest\` 339 tests on 3.12 + 3.13 | ✅ |
| Docker build smoke (linux/amd64) | ✅ |
| Image size guard (≤ 80 MB compressed) | ✅ |

## Test plan

- [x] All 5 required CI checks green on first push.
- [x] Workflow YAMLs static-validated via \`actionlint\` (no findings).
- [x] Device-ID consistency check across docs/ (single \`E17010000783\` everywhere).
- [x] Documentation cross-links resolve (every \`docs/*.md\` referenced by README exists; every \`_reference\` link in the new docs resolves to the existing reference document).
- [ ] Reviewer confirms commit history has no AI attribution.
- [ ] Reviewer renders \`docs/home-assistant.md\` on GitHub to verify the four code-block automation examples format cleanly (Markdown table + Jinja-in-YAML can occasionally surprise).