### PR TITLE
Phase 10 triage: CodeQL release-block fixes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,9 +36,19 @@ jobs:
         with:
           languages: python
           # Use the curated default query suite; we have not seen any
-          # noisy false positives that would justify a custom config
-          # yet. Re-evaluate when the codebase doubles in size.
+          # noisy false positives in production code that would justify
+          # a custom config yet. Re-evaluate when the codebase doubles
+          # in size.
           queries: security-and-quality
+          # CodeQL targets production code paths. Test fixtures are
+          # noisy under security-and-quality: testcontainer credential
+          # files are flagged as clear-text-storage (the password is a
+          # throwaway), assert-only statements as ineffectual,
+          # mock-bind locals as unused. Test code is filtered through
+          # ruff + mypy --strict + code review instead.
+          config: |
+            paths-ignore:
+              - tests/**
       - name: Run CodeQL analysis
         uses: github/codeql-action/analyze@v3
         with:

--- a/src/ez1_bridge/adapters/ez1_http.py
+++ b/src/ez1_bridge/adapters/ez1_http.py
@@ -59,13 +59,14 @@ def _is_transient(exc: BaseException) -> bool:
     standalone function (not a method) so tests can exercise the policy
     without instantiating a client.
     """
+    # Three explicit return paths, no guard fall-through. CodeQL's
+    # py/mixed-returns flagged the previous match-with-guard form
+    # because the guard's False arm fell through to ``case _``.
     match exc:
         case httpx.TimeoutException():
             return True
-        case httpx.HTTPStatusError() as e if (
-            _HTTP_SERVER_ERROR_LO <= e.response.status_code < _HTTP_SERVER_ERROR_HI
-        ):
-            return True
+        case httpx.HTTPStatusError() as e:
+            return _HTTP_SERVER_ERROR_LO <= e.response.status_code < _HTTP_SERVER_ERROR_HI
         case _:
             return False
 


### PR DESCRIPTION
## Why

PR #11 (develop → main) is blocked by GitHub's Code Scanning aggregate
check (`CodeQL`, non-required), reporting *16 new alerts including 1
high-severity security vulnerability* against develop. All 5 required
status checks on PR #11 are green.

Triage of the 16 alerts:

| Source | Count | Reading |
|---|---|---|
| `src/ez1_bridge/adapters/ez1_http.py:55` | 1 (note) | `py/mixed-returns` — real stylistic issue in production, fixable |
| `tests/integration/conftest.py:121` | 1 (high) | `clear-text-storage-sensitive-data` — testcontainer mosquitto passwd, throwaway hash, false positive |
| `tests/integration/conftest.py` (151/154/170/173) | 4 (error) | `uninitialized-local-variable` — fixture teardown control-flow, false positives |
| `tests/unit/*.py` | 10 (note) | `ineffectual-statement` / `unused-local-variable` — legitimate test idioms |

## What changes

Two atomic commits:

1. **`fix(adapters): ensure explicit return in EZ1 retry classifier`**
   Refactor `_is_transient` from a match-with-guard form (where the
   guard miss arm fell through to `case _`) to three unconditional
   match cases. CodeQL now sees three explicit return paths instead
   of inferring an implicit `None`. All 33 `tests/unit/test_ez1_http.py`
   tests still pass.

2. **`ci(codeql): exclude tests/** from analysis`**
   Add `paths-ignore: tests/**` to the `init` config. CodeQL is meant
   for production code paths; test fixtures generate context-blind
   false positives (testcontainer credential hashes, assert-only
   statements, mock-bind locals). Test code stays filtered through
   ruff + mypy --strict + code review.

The shape mirrors the user's hybrid plan: real production fix + targeted
config narrowing, no admin-override, no per-alert dismiss spam.

## Verification

* `uv run ruff check . && uv run ruff format --check .` — clean
* `uv run mypy src tests` — clean (`Success: no issues found in 40 source files`)
* `uv run pytest tests/unit -q` — 326 passed, 9.40 s
* `actionlint .github/workflows/codeql.yml` — exit 0
* CodeQL workflow on this PR should now produce 0 alerts (or 1 expected
  if the `py/mixed-returns` fix doesn't fully address the rule trigger
  — fall-back is one targeted dismiss).

## Follow-up

Once this merges into develop and the next CodeQL run on develop is
green, PR #11 should unblock. If pre-existing open alerts on develop
persist after the path filter takes effect, dismiss them via:

```bash
gh api -X PATCH /repos/baronblk/ez1-mqtt-bridge/code-scanning/alerts/<N> \
  -f state=dismissed -f dismissed_reason="false positive" \
  -f dismissed_comment="..."
```

No tag push, no release activity, until PR #11 is genuinely green.