### PR TITLE
Phase 10 release-prep: address copilot review + retire CodeQL alert #16

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,5 +42,5 @@ EZ1_BRIDGE_METRICS_PORT=9100
 # --- Logging --------------------------------------------------------------
 # Level: DEBUG | INFO | WARNING | ERROR
 EZ1_BRIDGE_LOG_LEVEL=INFO
-# Format: json | text | auto (auto = JSON when stdout is non-TTY, text otherwise)
+# Format: json | text | auto (auto = JSON when stderr is non-TTY, text otherwise)
 EZ1_BRIDGE_LOG_FORMAT=auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ beats feature velocity.
 | Security | `bandit`, `pip-audit` |
 | Pre-commit | `pre-commit` + `commitizen` |
 | CI | GitHub Actions |
-| Container | Multi-stage Dockerfile, distroless runtime, non-root |
+| Container | Multi-stage Dockerfile, `python:3.12-slim` runtime, non-root (UID 65532) |
 
 ---
 
@@ -70,9 +70,13 @@ uv run mypy src tests
 uv run pytest
 ```
 
-Coverage threshold scales with phase progress:
-- Phase 0: no threshold (smoke tests only).
-- Phase 1+: ≥ 85 % lines overall, 100 % on `domain/` and `application/`.
+Coverage gates as enforced in CI:
+- 100 % lines + branches on `domain/` (the inverted-on/off mapping
+  and watt-string parsers are too easy to silently regress).
+- ~98 % overall — the hard gate is the domain layer; adapter and
+  application coverage is high but not pinned at 100 % because
+  several integration paths are exercised end-to-end via
+  `testcontainers` rather than unit-mocked.
 
 Pre-commit runs the first three plus the conventional-commit message check
 on every `git commit`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ez1-mqtt-bridge"
-version = "0.0.0"
+version = "0.1.0"
 description = "MQTT bridge for the APsystems EZ1-M micro inverter with Home Assistant discovery and Prometheus metrics"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ez1_bridge/__init__.py
+++ b/src/ez1_bridge/__init__.py
@@ -2,6 +2,6 @@
 
 from typing import Final
 
-__version__: Final[str] = "0.0.0"
+__version__: Final[str] = "0.1.0"
 
 __all__ = ["__version__"]

--- a/src/ez1_bridge/adapters/ez1_http.py
+++ b/src/ez1_bridge/adapters/ez1_http.py
@@ -58,17 +58,18 @@ def _is_transient(exc: BaseException) -> bool:
     Drives the retry decision in :meth:`EZ1Client._request`. Defined as a
     standalone function (not a method) so tests can exercise the policy
     without instantiating a client.
+
+    Implemented as an ``isinstance``-chain rather than ``match`` because
+    CodeQL's ``py/mixed-returns`` analyser does not treat ``case _`` as
+    flow-sensitive exhaustive even when it is — the chain below is
+    semantically identical and gets a clean bill of health. The principle
+    of dispatching on exception type is preserved.
     """
-    # Three explicit return paths, no guard fall-through. CodeQL's
-    # py/mixed-returns flagged the previous match-with-guard form
-    # because the guard's False arm fell through to ``case _``.
-    match exc:
-        case httpx.TimeoutException():
-            return True
-        case httpx.HTTPStatusError() as e:
-            return _HTTP_SERVER_ERROR_LO <= e.response.status_code < _HTTP_SERVER_ERROR_HI
-        case _:
-            return False
+    if isinstance(exc, httpx.TimeoutException):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return _HTTP_SERVER_ERROR_LO <= exc.response.status_code < _HTTP_SERVER_ERROR_HI
+    return False
 
 
 def _backoff_seconds(attempt: int) -> float:

--- a/src/ez1_bridge/adapters/mqtt_publisher.py
+++ b/src/ez1_bridge/adapters/mqtt_publisher.py
@@ -3,9 +3,10 @@
 Designed as a thin, retain-aware wrapper around :class:`aiomqtt.Client`.
 The bridge owns one publisher instance for its entire lifetime and
 re-uses the underlying TCP connection — broker reconnect orchestration
-lives one layer up (Phase 6) rather than in the publisher itself, so the
-publisher can stay focused on "construct the right MQTT messages" and
-the application can decide what to do when the network drops.
+lives one layer up in :mod:`ez1_bridge.main` rather than in the publisher
+itself, so the publisher can stay focused on "construct the right MQTT
+messages" and the application can decide what to do when the network
+drops.
 
 LWT is set in the client *constructor*, not in any publish call; if the
 process dies ungracefully, the broker fires the configured
@@ -13,10 +14,10 @@ process dies ungracefully, the broker fires the configured
 the publisher after a catastrophic failure re-issues the LWT, since
 ``Will`` is bound to the underlying client object.
 
-The ``on_reconnect`` callback is wired here as a hook only; Phase 6
-will call :meth:`MQTTPublisher.trigger_reconnect_hook` from its
-reconnect loop to bump the ``ez1_mqtt_reconnects_total`` Prometheus
-counter. Until then, the hook is just a no-op default.
+The ``on_reconnect`` callback is wired here as a hook; the application's
+reconnect-orchestration loop calls :meth:`MQTTPublisher.trigger_reconnect_hook`
+on each successful re-establishment so ``ez1_mqtt_reconnects_total``
+advances. The publisher itself does not own the reconnect loop.
 """
 
 from __future__ import annotations
@@ -253,7 +254,7 @@ class MQTTPublisher:
     async def publish_result(self, command_name: str, payload: Mapping[str, Any]) -> None:
         """Publish a command-result event (``retain=False``).
 
-        Used by the Phase-5 command handler to acknowledge writes.
+        Used by the command handler to acknowledge writes.
         """
         client = self._ensure_client()
         await client.publish(
@@ -269,10 +270,10 @@ class MQTTPublisher:
     def trigger_reconnect_hook(self) -> None:
         """Invoke the ``on_reconnect`` callback if one was wired.
 
-        Phase 6's reconnect-orchestration loop calls this each time it
-        successfully re-establishes the broker connection so the
-        ``ez1_mqtt_reconnects_total`` Prometheus counter advances. The
-        publisher itself does not own the reconnect loop — that
+        The application's reconnect-orchestration loop calls this on
+        each successful re-establishment of the broker connection so
+        the ``ez1_mqtt_reconnects_total`` Prometheus counter advances.
+        The publisher itself does not own the reconnect loop — that
         responsibility lives in :mod:`ez1_bridge.main`.
         """
         if self._on_reconnect is not None:

--- a/src/ez1_bridge/adapters/prom_metrics.py
+++ b/src/ez1_bridge/adapters/prom_metrics.py
@@ -207,9 +207,14 @@ class MetricsRegistry:
     def increment_mqtt_publish(self, kind: str) -> None:
         """Count a single MQTT publish call by topic kind.
 
-        ``kind`` follows the canonical bucket vocabulary from
+        ``kind`` follows the canonical bucket vocabulary mirrored in
         :mod:`ez1_bridge.topics`: ``state``, ``flat``, ``availability``,
-        ``result``, ``discovery``.
+        ``result``, ``discovery``, plus the ``other`` sentinel emitted
+        by :meth:`MQTTPublisher.publish` when an arbitrary topic does
+        not match one of the typed shapes. The sentinel is a deliberate
+        bucket cap on label cardinality — without it, a future caller
+        of the generic publish helper could otherwise leak free-form
+        topic strings into the Prometheus index.
         """
         self.mqtt_publish.labels(kind=kind).inc()
 

--- a/src/ez1_bridge/application/poll_service.py
+++ b/src/ez1_bridge/application/poll_service.py
@@ -1,6 +1,7 @@
 """Periodic poll loop and availability heartbeat coroutines.
 
-Exposes the two coroutines that the main TaskGroup spawns in Phase 4:
+Exposes the two coroutines that the main TaskGroup spawns alongside
+the command handler and ``/metrics`` server:
 
 * :func:`poll_loop` — every ``settings.poll_interval`` seconds, hits the
   four EZ1 read endpoints in parallel, builds an :class:`InverterState`,
@@ -20,10 +21,6 @@ completion and then waits ``min(interval, until-stop)``, exiting
 promptly when the event is set. Errors inside an iteration are logged
 and swallowed so a transient failure (Nacht-offline, broker hiccup)
 does not bring the whole TaskGroup down.
-
-Phase 5 will add ``command_loop`` and Phase 6 will add ``metrics_server``;
-each is a sibling task in the same TaskGroup, sharing the same
-``stop_event``.
 """
 
 from __future__ import annotations

--- a/src/ez1_bridge/main.py
+++ b/src/ez1_bridge/main.py
@@ -2,16 +2,14 @@
 
 Two operating modes:
 
-* ``probe`` -- the read-only health check from Phase 2.
-* ``run`` -- the full bridge service (Phase 4 onwards): connects to
-  the broker, brings up an :class:`MQTTPublisher` and an
-  :class:`EZ1Client`, and starts an :class:`asyncio.TaskGroup` with
-  the poll loop and availability heartbeat.
-
-Phase 5 will add the command-handler task to the same TaskGroup;
-Phase 6 the metrics server. The TaskGroup skeleton in
-:func:`run_service` is the canonical orchestration point so those
-later phases only add ``tg.create_task(...)`` lines, not refactor.
+* ``probe`` -- a read-only health check that exercises every EZ1
+  endpoint once and reports the result. Mirrors the Docker
+  ``HEALTHCHECK`` in spirit but talks to the inverter directly.
+* ``run`` -- the full bridge service. Connects to the broker, brings
+  up an :class:`MQTTPublisher` and an :class:`EZ1Client`, and starts
+  an :class:`asyncio.TaskGroup` with four sibling coroutines: the
+  poll loop, the availability heartbeat, the command handler, and
+  the ``/metrics`` HTTP server.
 
 Signal handling routes ``SIGINT`` / ``SIGTERM`` to a single
 :class:`asyncio.Event` that every coroutine in the TaskGroup observes.
@@ -62,7 +60,7 @@ async def _probe(*, host: str, port: int, json_output: bool) -> int:
 
     Returns ``0`` if every endpoint responds with ``message == "SUCCESS"``,
     ``1`` otherwise. Designed for use as a CI smoke test against real
-    hardware (Phase 7) and as a quick local diagnostic.
+    hardware and as a quick local diagnostic.
 
     Never issues a write call. Adding a write endpoint to this routine
     would require a new fixture name and changes to the CLI surface --
@@ -166,11 +164,11 @@ async def run_service(
     fresh event is created. Tests pass an event explicitly so the
     function can be exercised without touching process-wide signals.
 
-    Phase 4 starts two tasks (poll loop + availability heartbeat).
-    Phase 5 adds the command handler; Phase 6 the metrics server. The
-    TaskGroup is the single orchestration point, and the surrounding
-    ``async with`` blocks ensure the EZ1 HTTP client and the MQTT
-    connection are torn down cleanly on any exit path.
+    The TaskGroup spawns four sibling coroutines (poll loop,
+    availability heartbeat, command handler, ``/metrics`` server) and
+    is the single orchestration point. The surrounding ``async with``
+    blocks ensure the EZ1 HTTP client and the MQTT connection are
+    torn down cleanly on any exit path.
     """
     own_stop_event = stop_event is None
     stop_event = stop_event or asyncio.Event()

--- a/src/ez1_bridge/topics.py
+++ b/src/ez1_bridge/topics.py
@@ -1,8 +1,8 @@
 """Centralized MQTT topic builders for the bridge.
 
 Every topic string in the codebase flows through this module — there are no
-magic strings anywhere else. Phase 4 (HA discovery) and Phase 5 (command
-handler) import the same builders so a topic-schema change ripples from
+magic strings anywhere else. The HA-discovery publisher and the command
+handler import the same builders so a topic-schema change ripples from
 exactly one place.
 
 Retain semantics

--- a/tests/unit/test_prom_metrics.py
+++ b/tests/unit/test_prom_metrics.py
@@ -149,6 +149,17 @@ def test_increment_mqtt_publish_by_kind() -> None:
     assert 'ez1_mqtt_publish_total{kind="flat"} 2.0' in text
 
 
+def test_increment_mqtt_publish_accepts_full_kind_vocabulary() -> None:
+    """Pin the documented `kind` vocabulary so future drift between
+    `MQTTPublisher.publish` and the registry docstring fails fast."""
+    metrics = MetricsRegistry()
+    for kind in ("state", "flat", "availability", "result", "discovery", "other"):
+        metrics.increment_mqtt_publish(kind)
+    text = metrics.generate().decode("utf-8")
+    for kind in ("state", "flat", "availability", "result", "discovery", "other"):
+        assert f'ez1_mqtt_publish_total{{kind="{kind}"}} 1.0' in text
+
+
 def test_increment_mqtt_reconnect_counter() -> None:
     metrics = MetricsRegistry()
     metrics.increment_mqtt_reconnect()

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -1,6 +1,7 @@
 """Smoke test — verifies that the package imports cleanly and exposes its version."""
 
 import re
+from importlib import metadata
 
 import ez1_bridge
 
@@ -13,3 +14,13 @@ def test_package_imports() -> None:
 def test_version_is_pep440_like() -> None:
     """``__version__`` follows a basic ``X.Y.Z[suffix]`` shape."""
     assert re.match(r"^\d+\.\d+\.\d+", ez1_bridge.__version__)
+
+
+def test_version_pinned_to_release() -> None:
+    """``__version__`` matches the pinned release; guards against the
+    pyproject/__init__ pair drifting apart on the next bump."""
+    # Pinning the runtime constant keeps `python -m ez1_bridge --version`
+    # honest after a release tag, and would have caught the v0.1.0 cut
+    # being prepared while metadata still claimed 0.0.0.
+    assert ez1_bridge.__version__ == "0.1.0"
+    assert metadata.version("ez1-mqtt-bridge") == ez1_bridge.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "ez1-mqtt-bridge"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Five reviewer findings on PR #11 (the develop → main release cut)
need to be addressed before the v0.1.0 tag. Two are release-blocking
(`version="0.0.0"` in two places); the rest are documentation
drift and one residual CodeQL alert.

This PR is **Variant C+** of the triage discussed in chat:

* **C** = code correctness + obvious doc drift (no CLAUDE.md
  micro-edits, no Befund 8 schema fix).
* **+** = Befund 8 included after inspection — the `kind="other"`
  sentinel is real (tests assert label values, docstring declares
  a vocabulary), but proportional fix is doc + test, not schema.

## Commits

Five atomic commits, each with its own tests where applicable:

| # | Commit | Why |
|---|--------|-----|
| 1 | `chore(release): bump version to 0.1.0` | `pyproject.toml` + `__init__.py` from `0.0.0` to `0.1.0`; new `test_version_pinned_to_release` guards against future drift |
| 2 | `refactor(adapters): dispatch retry classifier via isinstance for CodeQL flow-sensitivity` | `_is_transient` rewritten as isinstance-chain; CodeQL doesn't treat `case _` as flow-sensitive total catch |
| 3 | `docs: remove stale phase references from production docstrings` | Eight Phase-N references in `main.py`, `poll_service.py`, `mqtt_publisher.py`, `topics.py` removed; replaced with descriptions of current behaviour |
| 4 | `docs: align CLAUDE.md and .env.example with implemented behavior` | TTY detection on stderr (not stdout); `python:3.12-slim` runtime (not distroless); 100 % `domain/` coverage gate (not `domain/` + `application/`) |
| 5 | `docs(metrics): document `other` sentinel in mqtt publish kind vocabulary` | Registry docstring listed 5 kinds, code emits 6; new test `test_increment_mqtt_publish_accepts_full_kind_vocabulary` pins the full set |

## Verification

* `uv run ruff check .` — clean
* `uv run ruff format --check .` — 40 files already formatted
* `uv run mypy src tests` — `Success: no issues found in 40 source files`
* `uv run pytest tests/unit -q` — **328 passed** (326 + 2 new)
* Manual `python -m ez1_bridge --version` → prints `0.1.0`

## Expected effect on PR #11 after merge

* Befunde 1 + 2 (version bump) → **resolved**, `--version` prints 0.1.0.
* Befund 8 (publish kind drift) → **resolved**, registry doc + test
  pin the 6-element vocabulary.
* Befunde 3, 4, 5, 6, 7 (stale docs) → **resolved**.
* GHAS thread / CodeQL alert #16 → **resolved**, isinstance dispatch
  is unambiguously exhaustive to the analyser.
* PR #11 should transition `BLOCKED` → `CLEAN` once all 9 review
  threads are marked resolved (separate UI step after this merge).

## Out of scope

Reviewer's finding 8 has a stricter sibling: `MetricsRegistry` could
type the `kind` parameter as a `Literal[...]` instead of bare `str`.
Deliberate non-goal here — would require a callsite refactor that
does not belong in a release-prep window. Captured for v0.2.x.