### PR TITLE
chore(release): v0.1.1 — fix EZ1 parallel-poll bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-27
+
+### Fixed
+
+- **Poll cycle now serialises the four EZ1 read endpoints instead of
+  fanning them out via `asyncio.gather`.** The EZ1-M's local HTTP
+  server cannot handle parallel TCP connections — concurrent SYN
+  packets are dropped at the device, leaving every request in
+  connect-timeout. The bridge handled this correctly as a transient
+  transport error (no crash, `availability=offline` flipped, retry
+  next cycle), but no `state_published` event ever fired against
+  real hardware. Verified against firmware EZ1 1.12.2t. Worst-case
+  sequential latency ~2.8 s per cycle, well within the default 20 s
+  poll interval. Fixes [#14].
+- New regression test `test_poll_loop_serializes_ez1_endpoint_requests`
+  pins both the call order and the maximum in-flight count to 1; a
+  future return to `asyncio.gather` (or `asyncio.create_task`) trips
+  it deterministically.
+
+[#14]: https://github.com/baronblk/ez1-mqtt-bridge/issues/14
+
 ## [0.1.0] - 2026-04-27
 
 Initial release of the ez1-mqtt-bridge service.
@@ -127,5 +148,6 @@ Initial release of the ez1-mqtt-bridge service.
 - README with feature list, badges, configuration table, and CLI
   reference.
 
-[Unreleased]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/baronblk/ez1-mqtt-bridge/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ez1-mqtt-bridge"
-version = "0.1.0"
+version = "0.1.1"
 description = "MQTT bridge for the APsystems EZ1-M micro inverter with Home Assistant discovery and Prometheus metrics"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ez1_bridge/__init__.py
+++ b/src/ez1_bridge/__init__.py
@@ -2,6 +2,6 @@
 
 from typing import Final
 
-__version__: Final[str] = "0.1.0"
+__version__: Final[str] = "0.1.1"
 
 __all__ = ["__version__"]

--- a/src/ez1_bridge/application/poll_service.py
+++ b/src/ez1_bridge/application/poll_service.py
@@ -4,7 +4,7 @@ Exposes the two coroutines that the main TaskGroup spawns alongside
 the command handler and ``/metrics`` server:
 
 * :func:`poll_loop` — every ``settings.poll_interval`` seconds, hits the
-  four EZ1 read endpoints in parallel, builds an :class:`InverterState`,
+  four EZ1 read endpoints **sequentially**, builds an :class:`InverterState`,
   and publishes it. Also handles HA discovery: on the first successful
   cycle and every 24 h thereafter it fetches ``getDeviceInfo`` and
   publishes the 15 discovery messages built by :func:`build_discovery_messages`.
@@ -109,7 +109,7 @@ async def poll_loop(
 
     Each iteration:
 
-    1. Fetches the four read endpoints in parallel via ``asyncio.gather``.
+    1. Fetches the four read endpoints **sequentially** (see note below).
     2. Builds a typed :class:`InverterState` and publishes it.
     3. Mirrors the state onto the metrics registry's gauges (if provided).
     4. Republishes HA discovery if this is the first successful poll
@@ -121,12 +121,18 @@ async def poll_loop(
 
     while not stop_event.is_set():
         try:
-            output_data, max_power, alarm, on_off = await asyncio.gather(
-                ez1.get_output_data(),
-                ez1.get_max_power(),
-                ez1.get_alarm(),
-                ez1.get_on_off(),
-            )
+            # EZ1-M's local HTTP server cannot handle parallel TCP
+            # connections: parallel SYN packets are dropped, leaving
+            # every concurrent request stuck in connect-timeout.
+            # Verified against firmware EZ1 1.12.2t (issue #14).
+            # Worst-case sequential latency ~2.8 s at 0.7 s per request,
+            # well within the default 20 s poll interval. Do NOT replace
+            # this with `asyncio.gather` — it will look fine in unit
+            # tests and silently break against real hardware.
+            output_data = await ez1.get_output_data()
+            max_power = await ez1.get_max_power()
+            alarm = await ez1.get_alarm()
+            on_off = await ez1.get_on_off()
             now = datetime.now(tz=UTC)
             state = build_state(
                 output_data=output_data,

--- a/tests/unit/test_poll_service.py
+++ b/tests/unit/test_poll_service.py
@@ -100,6 +100,75 @@ async def test_poll_loop_publishes_state_and_discovery_on_first_cycle(
     assert publisher.publish.await_count == 15  # 11 sensor + 4 binary_sensor
 
 
+async def test_poll_loop_serializes_ez1_endpoint_requests(
+    api_response: Callable[[str], dict[str, Any]],
+) -> None:
+    """Pin the EZ1 endpoint call sequence to prevent regression to gather().
+
+    EZ1-M's local HTTP server cannot handle parallel TCP connections;
+    a switch to ``asyncio.gather`` would still pass mock-based tests
+    that ignore concurrency, then silently fail against real hardware
+    (issue #14). This test fails *both* on order changes and on any
+    overlap between calls.
+    """
+    stop_event = asyncio.Event()
+    ez1 = AsyncMock()
+
+    call_order: list[str] = []
+    in_flight = 0
+    max_concurrent = 0
+
+    def make_recorder(name: str, payload: dict[str, Any]) -> Callable[..., Any]:
+        async def _impl() -> dict[str, Any]:
+            nonlocal in_flight, max_concurrent
+            in_flight += 1
+            max_concurrent = max(max_concurrent, in_flight)
+            call_order.append(name)
+            # Yield to the event loop so a hypothetical `gather`
+            # implementation would observably overlap us with siblings.
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return payload
+
+        return _impl
+
+    ez1.get_output_data.side_effect = make_recorder(
+        "get_output_data", api_response("get_output_data")
+    )
+    ez1.get_max_power.side_effect = make_recorder("get_max_power", api_response("get_max_power"))
+    ez1.get_alarm.side_effect = make_recorder("get_alarm", api_response("get_alarm"))
+    ez1.get_on_off.side_effect = make_recorder("get_on_off", api_response("get_on_off"))
+    ez1.get_device_info.return_value = api_response("get_device_info")
+
+    publisher = AsyncMock()
+
+    async def stop_after_state(_state: object) -> None:
+        stop_event.set()
+
+    publisher.publish_state.side_effect = stop_after_state
+
+    await asyncio.wait_for(
+        poll_loop(
+            ez1=ez1,
+            publisher=publisher,
+            settings=_make_settings(),
+            stop_event=stop_event,
+        ),
+        timeout=2.0,
+    )
+
+    assert call_order == [
+        "get_output_data",
+        "get_max_power",
+        "get_alarm",
+        "get_on_off",
+    ]
+    assert max_concurrent == 1, (
+        f"EZ1 endpoint calls overlapped (max_concurrent={max_concurrent}); "
+        "regression to asyncio.gather()?"
+    )
+
+
 async def test_poll_loop_does_not_republish_discovery_within_refresh_window(
     api_response: Callable[[str], dict[str, Any]],
 ) -> None:

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -22,5 +22,5 @@ def test_version_pinned_to_release() -> None:
     # Pinning the runtime constant keeps `python -m ez1_bridge --version`
     # honest after a release tag, and would have caught the v0.1.0 cut
     # being prepared while metadata still claimed 0.0.0.
-    assert ez1_bridge.__version__ == "0.1.0"
+    assert ez1_bridge.__version__ == "0.1.1"
     assert metadata.version("ez1-mqtt-bridge") == ez1_bridge.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "ez1-mqtt-bridge"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release boundary for v0.1.1

Hot-fix on top of v0.1.0 for issue [#14] (EZ1-M cannot handle parallel
HTTP requests). Single fix landed via [#15](https://github.com/baronblk/ez1-mqtt-bridge/pull/15)
in four atomic commits on develop.

### What changed since v0.1.0

| | |
|---|---|
| `fix(poll): serialize EZ1 endpoint requests...` | Replace `asyncio.gather` over four read endpoints with sequential awaits. Inline comment carries the "do NOT replace with gather" warning |
| `test(poll): pin sequential EZ1 endpoint call order...` | New regression test asserts both call order and `max_concurrent==1`; trips deterministically on any return to gather/create_task |
| `chore(release): bump version to 0.1.1` | Pyproject + `__version__` + version-pin test |
| `docs: add [0.1.1] entry to CHANGELOG...` | Keep-a-Changelog entry, references #14 |

### Verification on develop

* CI on PR #15: 5/5 required checks SUCCESS
* `pytest tests/unit -q` — 329 passed (328 + new regression guard)
* `mypy --strict` — clean

### Why merge-commit, not rebase

Same rationale as the v0.1.0 release: the merge-commit on `main` is
the release boundary — `git log --first-parent main` shows exactly
the release tags as merge points, atomic commit history is preserved
on develop.

[#14]: https://github.com/baronblk/ez1-mqtt-bridge/issues/14