### PR TITLE
chore(release): v0.1.2 — production observability and multi-VLAN guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-27
+
+Bundled quality-fix release. Three follow-ups from the v0.1.1
+hardware smoke against E17010000783 (firmware EZ1 1.12.2t).
+
+### Added
+
+- Success-level logging for the three MQTT publish entry points.
+  `MQTTPublisher.publish_state` now emits a `state_published`
+  event with `device_id`, `power_w` (total), `energy_today_kwh`
+  (total), `status`, and `any_alarm`. `publish_availability`
+  emits `availability_published` with `online: bool`.
+  `publish_result` emits `command_result_published` with
+  `command`, `ok`, and `error`. Pinned by three new caplog tests
+  in `tests/unit/test_mqtt_publisher.py`.
+  Closes [#19].
+- New [`docs/troubleshooting.md`](docs/troubleshooting.md)
+  consolidating the field-verified failure modes:
+  multi-VLAN deployment requiring `network_mode: host`,
+  the four EZ1 hardware quirks (BLE app kills HTTP, parallel-
+  request rejection, WLAN volatility, `e1`/`e2` reset on cold
+  start), and the two diagnostic surfaces fixed in this release
+  (silent success path, hard-coded healthcheck port).
+  Closes [#17].
+
+### Fixed
+
+- Docker `HEALTHCHECK` now reads `EZ1_BRIDGE_METRICS_PORT` from
+  the container's environment instead of hard-coding port 9100.
+  Operators relocating the metrics port no longer get a false
+  `unhealthy` status. The probe stays on `127.0.0.1` because
+  in-container loopback is universal.
+  Closes [#18].
+
+### Why this matters
+
+The Phase 10 hardware smoke that surfaced v0.1.1's parallel-poll
+bug also surfaced an observability hole that masked the bug for
+~30 minutes: the bridge was working correctly but emitted no
+success-level log lines, so the diagnosis chased phantom causes
+(idle-connection timeout, TaskGroup hang, `_wait_or_stop` bug,
+keep-alive issue) before noticing the broker had retained state
+with live values. v0.1.2 closes that hole and writes down the
+EZ1 hardware quirks discovered along the way so the next operator
+saves the same time.
+
+[#17]: https://github.com/baronblk/ez1-mqtt-bridge/issues/17
+[#18]: https://github.com/baronblk/ez1-mqtt-bridge/issues/18
+[#19]: https://github.com/baronblk/ez1-mqtt-bridge/issues/19
+
 ## [0.1.1] - 2026-04-27
 
 ### Fixed
@@ -148,6 +198,7 @@ Initial release of the ez1-mqtt-bridge service.
 - README with feature list, badges, configuration table, and CLI
   reference.
 
-[Unreleased]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/baronblk/ez1-mqtt-bridge/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/baronblk/ez1-mqtt-bridge/releases/tag/v0.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,8 +98,13 @@ USER nonroot
 # Importantly, this must NOT fail when the EZ1 inverter is offline at
 # night: the bridge stays healthy (bridge_up=1, /metrics responds) even
 # while availability=offline -- that is the intended split.
+#
+# The probe always targets 127.0.0.1 (the in-container loopback always
+# works regardless of how the metrics server is bound) but reads the
+# port from EZ1_BRIDGE_METRICS_PORT so an operator who relocates the
+# scrape port does not have to rebuild the image. Issue #18.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD ["python", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9100/metrics', timeout=4).status == 200 else 1)"]
+    CMD ["python", "-c", "import os,urllib.request,sys;p=os.environ.get('EZ1_BRIDGE_METRICS_PORT','9100');sys.exit(0 if urllib.request.urlopen(f'http://127.0.0.1:{p}/metrics', timeout=4).status == 200 else 1)"]
 
 EXPOSE 9100
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ auto-discovery and Prometheus metrics.
 | [`docs/mqtt-topics.md`](docs/mqtt-topics.md) | Every published / subscribed / discovery topic with payload schemas |
 | [`docs/home-assistant.md`](docs/home-assistant.md) | Integration guide with copy-paste automation examples |
 | [`docs/api-reference.md`](docs/api-reference.md) | EZ1 endpoint summary + firmware compatibility |
+| [`docs/troubleshooting.md`](docs/troubleshooting.md) | Multi-VLAN setup, EZ1 hardware quirks, common failure-mode diagnoses |
 | [`docs/_reference/apsystems-ez1-local-api.md`](docs/_reference/apsystems-ez1-local-api.md) | Canonical local-API reference (verified payloads + edge cases) |
 
 ## Container deployment

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,174 @@
+# Troubleshooting
+
+Field-verified failure modes from real deployments, ordered roughly
+by frequency. If your symptom is "the bridge starts cleanly but no
+`state_published` events ever appear in the logs", read this page
+top-to-bottom — at least three different root causes share that
+exact surface symptom.
+
+## Multi-VLAN deployments — bridge needs `network_mode: host`
+
+**Symptom.** Bridge connects to MQTT cleanly, publishes
+`availability=online`, runs the HA discovery, then every poll
+cycle logs `ez1_unreachable` and the bridge keeps flipping
+`availability=offline`. `curl http://<EZ1>:8050/getDeviceInfo`
+from the *host* succeeds, so the inverter is alive — only the
+container cannot reach it.
+
+**Root cause.** The default [`docker-compose.yml`](../docker-compose.yml)
+puts the bridge on a Docker bridge network (`networks: [bridge-net]`).
+That bridge has a route to the host's *default* subnet but not to
+other VLANs the host can reach via inter-VLAN routing. The Docker
+network's gateway does not know about your managed-switch VLANs.
+
+**Fix.** Switch the bridge to host-network mode:
+
+```yaml
+services:
+  bridge:
+    image: ghcr.io/baronblk/ez1-mqtt-bridge:0.1.2
+    network_mode: host
+    # When in host mode, remove these two keys — they have no effect
+    # and Docker will reject the compose file:
+    # ports:
+    #   - "127.0.0.1:9100:9100"
+    # networks:
+    #   - bridge-net
+    environment:
+      EZ1_BRIDGE_EZ1_HOST: 192.168.3.24
+      EZ1_BRIDGE_MQTT_HOST: 192.168.2.10
+      EZ1_BRIDGE_METRICS_BIND: 127.0.0.1   # tighten from default 0.0.0.0
+      # ... rest of the env as usual
+```
+
+**Trade-offs to know.** Host mode means port 9100 collides with
+anything else the host listens on (other Prometheus exporters,
+another bridge instance, etc.). Tighten `EZ1_BRIDGE_METRICS_BIND`
+from the default `0.0.0.0` to `127.0.0.1` so the metrics server
+is not advertised on every host interface — Prometheus scrapes
+loopback fine, and you avoid the public-exposure footgun.
+
+**When you do not need this.** Single-VLAN setups where bridge,
+broker, and EZ1 all live on the same subnet — the default
+bridge-network compose works as-is.
+
+## EZ1 hardware quirks
+
+The inverter has four field-verified behavioural quirks. Read these
+once, save yourself the diagnostic loop later.
+
+### 1. Bluetooth-app connection kills the local HTTP server
+
+When AP EasyPower is connected to the inverter via BLE, the local
+HTTP API on port 8050 stops responding to TCP connections.
+`curl http://<EZ1>:8050/getDeviceInfo` hangs in connect-timeout.
+Closing the app fully (force-quit on iOS, swipe-away on Android)
+restores the API after a few seconds.
+
+**Reproduces:** firmware EZ1 1.12.2t, verified live during the
+2026-04-27 hardware smoke.
+
+**Operational rule:** before debugging a "bridge can't reach the
+inverter" issue, make sure no phone in the household has the
+EasyPower app open in the background.
+
+### 2. Parallel HTTP requests are dropped
+
+The local HTTP server accepts only one TCP connection at a time.
+Concurrent SYN packets from the same or different clients are
+dropped at the device. The bridge already serialises its four
+poll endpoints (issue #14, fixed in v0.1.1), but if *another*
+script also polls the same inverter, run them sequentially or
+not concurrently with the bridge.
+
+A simple test from the host:
+
+```bash
+# 5 sequential requests, 5 s apart — all SUCCESS
+for i in 1 2 3 4 5; do curl -s -o /dev/null -w "%{http_code} %{time_total}s\n" \
+  http://192.168.3.24:8050/getDeviceInfo; sleep 5; done
+
+# 4 parallel requests — all hit connect-timeout
+for ep in getOutputData getMaxPower getAlarm getOnOff; do
+  curl -s --max-time 10 -o /dev/null -w "$ep: %{http_code} %{time_total}s\n" \
+    "http://192.168.3.24:8050/$ep" &
+done; wait
+```
+
+### 3. WLAN module is volatile
+
+The EZ1's WiFi stack will silently drop off the network after
+multi-day uptimes. The inverter is still producing power; only
+the local API is unreachable. Only a power-cycle reliably
+restores it.
+
+The bridge already handles this gracefully: every cycle that ends
+in `httpx.ConnectError` flips `availability=offline`, and the
+poll loop retries on the next interval. Home Assistant shows
+the device as Unavailable until WLAN comes back. No code change
+on the bridge side helps here — escalate to the inverter vendor.
+
+**Operational rule:** if `availability=offline` persists for more
+than a poll-interval, ssh into the host and run a fresh `curl`.
+If that also hangs, power-cycle the EZ1.
+
+### 4. `e1` / `e2` reset on cold start
+
+The energy "today" counters in `getOutputData` are really
+"since last cold start". A mid-day cloud-induced inverter shutdown
+can reset them. The bridge faithfully publishes whatever the
+inverter reports.
+
+**This is not a data-loss bug in the bridge.** Home Assistant's
+Energy Dashboard tolerates `state_class: total_increasing` resets
+correctly; the bridge sets that class on the energy sensors via
+HA discovery so the dashboard handles the reset for you.
+
+The full per-endpoint reference is at
+[`_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md);
+the `e1`/`e2` reset semantics are documented there in detail.
+
+## Bridge logs show silence after `ha_discovery_published`
+
+**Symptom.** Bridge starts, logs `bridge_starting`,
+`ez1_device_resolved`, `metrics_server_started`,
+`command_loop_subscribed`, `ha_discovery_published` — then nothing
+for minutes. The MQTT broker shows retained `availability=online`
+and a fresh `state` JSON on the topic, but the bridge logs are
+silent.
+
+**Root cause.** Up to and including v0.1.1, `publish_state` and
+`publish_availability` did not emit a success-level log line. The
+bridge was working perfectly; the operator was blind.
+
+**Fix.** Upgrade to v0.1.2 or later. Each cycle now logs
+`state_published` with the live `power_w`, `energy_today_kwh`,
+`status`, and `any_alarm`; each heartbeat logs
+`availability_published` with the `online: bool`. Issue #19.
+
+## Healthcheck reports `unhealthy` despite a working bridge
+
+**Symptom.** `docker ps` shows the bridge as `unhealthy` even
+though `/metrics` returns 200 when probed manually from the host
+or another container.
+
+**Root cause.** Up to and including v0.1.1, the Dockerfile
+HEALTHCHECK probed `127.0.0.1:9100` regardless of the configured
+`EZ1_BRIDGE_METRICS_PORT`. If you remapped the metrics port to
+something other than 9100 (port collision, multi-bridge setup),
+the probe targeted a port nobody listened on.
+
+**Fix.** Upgrade to v0.1.2 or later — the HEALTHCHECK now reads
+`EZ1_BRIDGE_METRICS_PORT` from the environment. Issue #18.
+
+## See also
+
+* [`docs/architecture.md`](architecture.md) — repository layout
+  and the four-coroutine TaskGroup orchestration.
+* [`docs/api-reference.md`](api-reference.md) — EZ1 endpoint
+  summary, firmware compatibility, and the original reset-on-cold-start
+  reference.
+* [`docs/home-assistant.md`](home-assistant.md) — HA integration,
+  automation examples, and the discovery refresh cadence.
+* [`docs/_reference/apsystems-ez1-local-api.md`](_reference/apsystems-ez1-local-api.md)
+  — canonical EZ1 local-API documentation with verified payloads.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ez1-mqtt-bridge"
-version = "0.1.1"
+version = "0.1.2"
 description = "MQTT bridge for the APsystems EZ1-M micro inverter with Home Assistant discovery and Prometheus metrics"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ez1_bridge/__init__.py
+++ b/src/ez1_bridge/__init__.py
@@ -2,6 +2,6 @@
 
 from typing import Final
 
-__version__: Final[str] = "0.1.1"
+__version__: Final[str] = "0.1.2"
 
 __all__ = ["__version__"]

--- a/src/ez1_bridge/adapters/mqtt_publisher.py
+++ b/src/ez1_bridge/adapters/mqtt_publisher.py
@@ -28,6 +28,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, Final, Self
 
 import aiomqtt
+import structlog
 from pydantic import SecretStr
 
 from ez1_bridge import topics
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
     from ez1_bridge.adapters.prom_metrics import MetricsRegistry
 
 _DEFAULT_QOS: Final[int] = 1
+_log = structlog.get_logger(__name__)
 
 
 def _flat_pairs(state: InverterState) -> list[tuple[str, str, str]]:
@@ -204,6 +206,7 @@ class MQTTPublisher:
             retain=topics.RETAIN["availability"],
         )
         self._record_publish("availability")
+        _log.info("availability_published", online=online, device_id=self._device_id)
 
     async def publish_state(self, state: InverterState) -> None:
         """Publish the structured JSON state plus all flat per-metric topics.
@@ -228,6 +231,14 @@ class MQTTPublisher:
                 retain=topics.RETAIN["flat"],
             )
             self._record_publish("flat")
+        _log.info(
+            "state_published",
+            device_id=state.device_id,
+            power_w=state.power.total_w,
+            energy_today_kwh=state.energy_today.total_kwh,
+            status=state.status,
+            any_alarm=state.alarms.any_active,
+        )
 
     async def publish(
         self,
@@ -264,6 +275,13 @@ class MQTTPublisher:
             retain=topics.RETAIN["result"],
         )
         self._record_publish("result")
+        _log.info(
+            "command_result_published",
+            command=command_name,
+            ok=payload.get("ok"),
+            error=payload.get("error"),
+            device_id=self._device_id,
+        )
 
     # --- Reconnect-counter hook -----------------------------------------
 

--- a/tests/unit/test_mqtt_publisher.py
+++ b/tests/unit/test_mqtt_publisher.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import aiomqtt
 import pytest
+import structlog
 from pydantic import SecretStr
 
 from ez1_bridge import topics
@@ -303,6 +304,86 @@ async def test_publish_result_does_not_retain() -> None:
     assert awaited_call.kwargs["retain"] is False
     body = json.loads(awaited_call.kwargs["payload"])
     assert body == {"ok": True, "value": 600}
+
+
+# --- Success-level logging --------------------------------------------
+#
+# These tests pin the success-path log events introduced in v0.1.2.
+# Without a success log, a healthy bridge looks indistinguishable from
+# a hung one in journalctl: the v0.1.1 hardware smoke spent ~30 minutes
+# diagnosing a phantom hang before noticing the bridge was working all
+# along (issue #19).
+
+
+async def test_publish_state_emits_state_published_log(
+    sample_state: InverterState,
+) -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E17010000783")
+
+    with (
+        patch.object(pub, "_build_client", return_value=mock_client),
+        structlog.testing.capture_logs() as captured,
+    ):
+        async with pub:
+            await pub.publish_state(sample_state)
+
+    state_logs = [e for e in captured if e.get("event") == "state_published"]
+    assert len(state_logs) == 1
+    log = state_logs[0]
+    assert log["device_id"] == "E17010000783"
+    assert log["power_w"] == 204.0
+    assert log["energy_today_kwh"] == pytest.approx(0.71384)
+    assert log["status"] == "on"
+    assert log["any_alarm"] is False
+    assert log["log_level"] == "info"
+
+
+async def test_publish_availability_emits_availability_published_log() -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with (
+        patch.object(pub, "_build_client", return_value=mock_client),
+        structlog.testing.capture_logs() as captured,
+    ):
+        async with pub:
+            await pub.publish_availability(online=True)
+            await pub.publish_availability(online=False)
+
+    avail_logs = [e for e in captured if e.get("event") == "availability_published"]
+    assert len(avail_logs) == 2
+    assert avail_logs[0]["online"] is True
+    assert avail_logs[1]["online"] is False
+    assert all(e["device_id"] == "E1" for e in avail_logs)
+    assert all(e["log_level"] == "info" for e in avail_logs)
+
+
+async def test_publish_result_emits_command_result_published_log() -> None:
+    mock_client = _mock_client()
+    pub = MQTTPublisher("broker.local", device_id="E1")
+
+    with (
+        patch.object(pub, "_build_client", return_value=mock_client),
+        structlog.testing.capture_logs() as captured,
+    ):
+        async with pub:
+            await pub.publish_result("max_power", {"ok": True, "value": 600})
+            await pub.publish_result(
+                "on_off",
+                {"ok": False, "error": "invalid_payload", "detail": "..."},
+            )
+
+    result_logs = [e for e in captured if e.get("event") == "command_result_published"]
+    assert len(result_logs) == 2
+
+    success, failure = result_logs
+    assert success["command"] == "max_power"
+    assert success["ok"] is True
+    assert success["error"] is None  # absent → defaulted to None by .get()
+    assert failure["command"] == "on_off"
+    assert failure["ok"] is False
+    assert failure["error"] == "invalid_payload"
 
 
 # --- Reconnect hook ---------------------------------------------------

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -22,5 +22,5 @@ def test_version_pinned_to_release() -> None:
     # Pinning the runtime constant keeps `python -m ez1_bridge --version`
     # honest after a release tag, and would have caught the v0.1.0 cut
     # being prepared while metadata still claimed 0.0.0.
-    assert ez1_bridge.__version__ == "0.1.1"
+    assert ez1_bridge.__version__ == "0.1.2"
     assert metadata.version("ez1-mqtt-bridge") == ez1_bridge.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "ez1-mqtt-bridge"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Release boundary for v0.1.2

Bundled quality-fix release atop v0.1.1, closing three follow-ups
from the v0.1.1 hardware smoke.

Single PR landed via [#20](https://github.com/baronblk/ez1-mqtt-bridge/pull/20)
in five atomic commits on develop.

### What changed since v0.1.1

| Commit | Closes |
|--------|--------|
| `feat(mqtt): add success-level logging to publish methods` | [#19](https://github.com/baronblk/ez1-mqtt-bridge/issues/19) |
| `fix(docker): align healthcheck with configurable EZ1_BRIDGE_METRICS_PORT` | [#18](https://github.com/baronblk/ez1-mqtt-bridge/issues/18) |
| `docs: add troubleshooting guide with multi-VLAN setup and EZ1 quirks` | [#17](https://github.com/baronblk/ez1-mqtt-bridge/issues/17) |
| `chore(release): bump version to 0.1.2` | — |
| `docs: add [0.1.2] section to CHANGELOG...` | — |

### Verification on develop

* CI on PR #20: 5/5 required checks SUCCESS (Lint, Type, Test 3.12,
  Test 3.13, Docker build smoke — the docker-build job exercises
  the new HEALTHCHECK env-var read end-to-end).
* `pytest tests/unit -q` — 332 passed (329 + 3 new caplog tests
  for the publish events).
* `mypy --strict` — clean.

### Why merge-commit

Same rationale as v0.1.0 and v0.1.1: the merge-commit on `main`
is the release boundary. `git log --first-parent main` is now:

```
6f3e869  v0.1.1 (parallel-poll fix)
ad6658a  v0.1.0 (initial)
8612d96  init
```

After this merge:

```
<new>    v0.1.2 (observability + docs)
6f3e869  v0.1.1
ad6658a  v0.1.0
8612d96  init
```

A clean release timeline reachable with one git command.